### PR TITLE
carthage 1.0.4

### DIFF
--- a/steps/carthage/1.0.4/step.yml
+++ b/steps/carthage/1.0.4/step.yml
@@ -1,0 +1,70 @@
+title: Carthage
+summary: Installs and updates Carthage to the latest available version and runs selected
+  Carthage command.
+description: |-
+  Installs and updates Carthage to the latest available version and runs selected Carthage command.
+  For more information about Carthage, visit the [Carthage GitHub page](https://github.com/Carthage/Carthage).
+website: https://github.com/vasarhelyia/steps-carthage
+source_code_url: https://github.com/vasarhelyia/steps-carthage
+support_url: https://github.com/vasarhelyia/steps-carthage/issues
+published_at: 2015-11-28T23:15:53.627741292+01:00
+source:
+  git: https://github.com/vasarhelyia/steps-carthage.git
+  commit: f955d6f6393bd1b1daf2a9479b6e116fc99dfcb1
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- carthage
+- system
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- carthage_command: bootstrap
+  opts:
+    description: |-
+      Select a command to set up your dependencies with.
+      * `bootstrap`: initializes the project with checking out & building all dependencies. (default)
+      * `update`: updates all dependencies.
+      * `build`: builds all checked out items.
+    summary: Select a command to set up your dependencies with.
+    title: Carthage command to run
+    value_options:
+    - bootstrap
+    - update
+    - build
+- no_use_binaries: "false"
+  opts:
+    summary: |-
+      Use this flag to make sure Carthage checks out all dependencies (otherwise
+      it defaults to binary framework releases). False by default.
+    title: Set no use binaries flag
+    value_options:
+    - "true"
+    - "false"
+- opts:
+    summary: Use this flag to have a verbose output of the carthage command. False
+      by default.
+    title: Set verbose output flag
+    value_options:
+    - "true"
+    - "false"
+  verbose_output: "false"
+- opts:
+    description: |
+      This directory will be set as the current working
+      directory for the carthage command.
+    title: Working directory
+  working_dir: null
+- opts:
+    description: |
+      Choose which platform to build your dependencies for.
+    title: Platform
+    value_options:
+    - iOS
+    - Mac
+    - iOS,Mac
+  platform: iOS


### PR DESCRIPTION
Make `platform` an input param, letting `carthage` to build for Mac as well.