### PR TITLE
xcode-archive-mac 1.0.0

### DIFF
--- a/steps/xcode-archive-mac/1.0.0/step.yml
+++ b/steps/xcode-archive-mac/1.0.0/step.yml
@@ -1,0 +1,127 @@
+title: Xcode Archive for Mac
+summary: |-
+  Create an archive for your OS X project so you can share it, upload it, deploy it and catch them
+  all! Well, maybe not the last one.
+description: ""
+website: https://github.com/vasarhelyia/steps-new-xcode-archive-mac
+source_code_url: https://github.com/vasarhelyia/steps-new-xcode-archive-mac
+support_url: https://github.com/vasarhelyia/steps-new-xcode-archive-mac/issues
+published_at: 2015-12-26T11:04:24.152667471+01:00
+source:
+  git: https://github.com/vasarhelyia/steps-xcode-archive-mac.git
+  commit: 2bc746cf85e65817ccc5347b1b4a2134b404a7e5
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- mac
+type_tags:
+- build
+- xcode
+deps:
+  check_only:
+  - name: xcode
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      Working directory of the step.
+      You can leave it empty to don't change it.
+    is_required: false
+    summary: ""
+    title: Working directory
+  workdir: $BITRISE_SOURCE_DIR
+- opts:
+    description: |
+      A `.xcodeproj` or `.xcworkspace` path.
+    is_required: true
+    summary: ""
+    title: Project (or Workspace) path
+  project_path: $BITRISE_PROJECT_PATH
+- opts:
+    description: |
+      The Scheme to use.
+    is_required: true
+    summary: ""
+    title: Scheme name
+  scheme: $BITRISE_SCHEME
+- configuration: null
+  opts:
+    description: |
+      (optional) The configuration to use. By default your Scheme
+      defines which configuration (Debug, Release, ...) should be used,
+      but you can overwrite it with this option.
+      **Make sure that the Configuration you specify actually exists
+      in your Xcode Project**. If it does not, if you have a typo
+      in the value of this input Xcode will simply use the Configuration
+      specified by the Scheme and will silently ignore this parameter!
+    is_required: false
+    summary: ""
+    title: Configuration name
+- opts:
+    description: |
+      This directory will contain the generated Xcode archive (.xcarchive)
+      and the .app file.
+    is_required: false
+    summary: ""
+    title: Output directory path
+  output_dir: $BITRISE_DEPLOY_DIR
+- is_force_code_sign: "no"
+  opts:
+    description: |-
+      If set to "yes" then it'll use the `PROVISIONING_PROFILE` (set
+      to the value of the `$BITRISE_PROVISIONING_PROFILE_ID` environment)
+      and `CODE_SIGN_IDENTITY` (set to the value
+      of the `$BITRISE_CODE_SIGN_IDENTITY` environment)
+      Xcode Command Line parameters,
+      for force the use of specified Certificate and Provisioning Profile,
+      to the ones
+    is_expand: false
+    is_required: true
+    title: Use force code signing attributes?
+    value_options:
+    - "yes"
+    - "no"
+- export_options_path: null
+  opts:
+    description: |-
+      Used for Xcode version 7 and above.
+      Specifies a path to a plist file that configures archive exporting.
+      If empty, step generates these options based on provisioning profile,
+      in case of the methods development, or App Store.
+      Auto generated export options available for export methods:
+      - app-store
+      - development
+      If step doesn't find export method based on provisioning profile, development will be use.
+      If you would like to export a Developer ID signed application, please create a plist with the corresponding method.
+      Call xcodebuild -help for available export options.
+    is_expand: true
+    is_required: false
+    title: Export options path
+- is_clean_build: "yes"
+  opts:
+    is_required: true
+    title: Do a clean Xcode build before the archive?
+    value_options:
+    - "yes"
+    - "no"
+- opts:
+    description: |-
+      If output_tool is set to xcpretty, the xcodebuild output will be prettified by xcpretty.
+      If output_tool is set to xcodebuild, the raw xcodebuild output will be printed.
+    is_expand: false
+    is_required: true
+    title: Output tool
+    value_options:
+    - xcpretty
+    - xcodebuild
+  output_tool: xcpretty
+outputs:
+- BITRISE_APP_PATH: null
+  opts:
+    title: The created .app file's path
+- BITRISE_DSYM_PATH: null
+  opts:
+    title: The created .dSYM.zip file's path


### PR DESCRIPTION
generates/handles export options plist for Xcode 7.0 or above projects