### PR TITLE
xcode-archive-mac 1.1.0

### DIFF
--- a/steps/xcode-archive-mac/1.1.0/step.yml
+++ b/steps/xcode-archive-mac/1.1.0/step.yml
@@ -1,0 +1,141 @@
+title: Xcode Archive for Mac
+summary: |-
+  Create an archive for your OS X project so you can share it, upload it, deploy it and catch them
+  all! Well, maybe not the last one.
+description: ""
+website: https://github.com/vasarhelyia/steps-new-xcode-archive-mac
+source_code_url: https://github.com/vasarhelyia/steps-new-xcode-archive-mac
+support_url: https://github.com/vasarhelyia/steps-new-xcode-archive-mac/issues
+published_at: 2016-01-04T20:51:25.199715496+01:00
+source:
+  git: https://github.com/vasarhelyia/steps-xcode-archive-mac.git
+  commit: f1b74d027b7c1ede50a57a0975e695ae02ca73b8
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- mac
+type_tags:
+- build
+- xcode
+deps:
+  check_only:
+  - name: xcode
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      Working directory of the step.
+      You can leave it empty to don't change it.
+    is_required: false
+    summary: ""
+    title: Working directory
+  workdir: $BITRISE_SOURCE_DIR
+- opts:
+    description: |
+      A `.xcodeproj` or `.xcworkspace` path.
+    is_required: true
+    summary: ""
+    title: Project (or Workspace) path
+  project_path: $BITRISE_PROJECT_PATH
+- opts:
+    description: |
+      The Scheme to use.
+    is_required: true
+    summary: ""
+    title: Scheme name
+  scheme: $BITRISE_SCHEME
+- configuration: null
+  opts:
+    description: |
+      (optional) The configuration to use. By default your Scheme
+      defines which configuration (Debug, Release, ...) should be used,
+      but you can overwrite it with this option.
+      **Make sure that the Configuration you specify actually exists
+      in your Xcode Project**. If it does not, if you have a typo
+      in the value of this input Xcode will simply use the Configuration
+      specified by the Scheme and will silently ignore this parameter!
+    is_required: false
+    summary: ""
+    title: Configuration name
+- opts:
+    description: |
+      This directory will contain the generated Xcode archive (.xcarchive)
+      and the .app file.
+    is_required: false
+    summary: ""
+    title: Output directory path
+  output_dir: $BITRISE_DEPLOY_DIR
+- is_force_code_sign: "no"
+  opts:
+    description: |-
+      If set to "yes" then it'll use the `PROVISIONING_PROFILE` (set
+      to the value of the `$BITRISE_PROVISIONING_PROFILE_ID` environment)
+      and `CODE_SIGN_IDENTITY` (set to the value
+      of the `$BITRISE_CODE_SIGN_IDENTITY` environment)
+      Xcode Command Line parameters,
+      for force the use of specified Certificate and Provisioning Profile,
+      to the ones
+    is_expand: false
+    is_required: true
+    title: Use force code signing attributes?
+    value_options:
+    - "yes"
+    - "no"
+- export_options_path: null
+  opts:
+    description: |-
+      Used for Xcode version 7 and above.
+      Specifies a path to a plist file that configures archive exporting.
+      Call xcodebuild -help for available export options.
+    is_expand: true
+    is_required: false
+    title: Export options path
+- export_format: APP
+  opts:
+    description: '"In case of an Xcode 6 build, the format of the export has to be
+      specified as APP or PKG."'
+    is_required: true
+    title: Export format
+    value_options:
+    - APP
+    - PKG
+- export_method: development
+  opts:
+    description: |-
+      The method for exporting used in `exportOptions` plist, relevant for builds with Xcode version 7 and above.
+      See `xcodebuild -help` for more information.
+    is_required: true
+    title: Export method
+    value_options:
+    - app-store
+    - development
+    - developer-id
+    - none
+- is_clean_build: "yes"
+  opts:
+    is_required: true
+    title: Do a clean Xcode build before the archive?
+    value_options:
+    - "yes"
+    - "no"
+- opts:
+    description: |-
+      If output_tool is set to xcpretty, the xcodebuild output will be prettified by xcpretty.
+      If output_tool is set to xcodebuild, the raw xcodebuild output will be printed.
+    is_expand: false
+    is_required: true
+    title: Output tool
+    value_options:
+    - xcpretty
+    - xcodebuild
+  output_tool: xcpretty
+outputs:
+- BITRISE_EXPORTED_FILE_PATH: null
+  opts:
+    title: The created .app or .pkg file's path
+- BITRISE_DSYM_PATH: null
+  opts:
+    title: The created .dSYM.zip file's path


### PR DESCRIPTION
Proper handling of `export` methods as input.  Add support for `pkg` export.