### PR TITLE
gradle-coveralls 1.0.1

### DIFF
--- a/steps/gradle-coveralls/1.0.1/step.yml
+++ b/steps/gradle-coveralls/1.0.1/step.yml
@@ -1,0 +1,45 @@
+title: Gradle Coveralls
+summary: Runs Coveralls with `./gradlew`.
+description: Sends code coverage to www.coveralls.io. Uses `./gradlew coveralls` task.
+  You have to configure [org.kt3k.gradle.plugin:coveralls-gradle-plugin](https://github.com/kt3k/coveralls-gradle-plugin)
+  in your project first.
+website: https://github.com/donvigo/steps-gradle-coveralls
+source_code_url: https://github.com/donvigo/steps-gradle-coveralls
+support_url: https://github.com/donvigo/steps-gradle-coveralls/issues
+published_at: 2016-01-18T13:09:09.295008122+02:00
+source:
+  git: https://github.com/donvigo/steps-gradle-coveralls.git
+  commit: 83e6ca708c9ffc4924108a8635d3c3dd32581d40
+host_os_tags:
+- ubuntu
+project_type_tags:
+- android
+type_tags:
+- coveralls
+- gradle
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+inputs:
+- gradlew_file_path: $GRADLEW_PATH
+  opts:
+    description: |
+      Path for the gradlew file
+    is_expand: true
+    is_required: true
+    title: Path for the gradlew file
+- coveralls_task: coveralls
+  opts:
+    description: |
+      The coveralls task to execute by gradlew
+    is_expand: true
+    is_required: true
+    title: Coveralls gradle task
+- coveralls_repo_token: null
+  opts:
+    description: "The secret repo token for your repository, \nfound at the bottom
+      of your repository's page on Coveralls. \nStrongly recommended to keep this
+      variable in \"Secret Environment Variables\" section.\t\n"
+    is_expand: true
+    is_required: true
+    title: Coveralls repo token


### PR DESCRIPTION
Added `coveralls_repo_token` to the `inputs`. 
In `1.0.0` version, COVERALLS_REPO_TOKEN should be exported manually. Now it will be exported by the step automatically.