### PR TITLE
applivery-ios 0.1.1

### DIFF
--- a/steps/applivery-ios/0.1.1/step.yml
+++ b/steps/applivery-ios/0.1.1/step.yml
@@ -1,0 +1,93 @@
+title: Applivery.com iOS Deploy
+summary: Deploy your awesome iOS Application to Applivery.com
+description: |-
+  Deploy an iOS application to [Applivery](http://www.applivery.com),
+  add notes and notify testers.
+
+  Register a Applivery account at [http://www.applivery..com/](http://www.applivery.com)
+  and create an App to utilize this step.
+
+  You also need to get your *Account API Key* for you account and the *App Id* for the app.
+website: https://github.com/applivery/steps-applivery-ios-deploy
+source_code_url: https://github.com/applivery/steps-applivery-ios-deploy
+support_url: https://github.com/applivery/steps-applivery-ios-deploy/issues
+published_at: 2016-02-08T21:08:30.248904107+01:00
+source:
+  git: https://github.com/applivery/steps-applivery-ios-deploy.git
+  commit: e770b31324534126ba52a2ed84027dc86999e035
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- deploy
+- Applivery
+- iOS
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: .IsCI
+inputs:
+- ipa_path: $BITRISE_IPA_PATH
+  opts:
+    description: ""
+    is_required: true
+    summary: ""
+    title: IPA file path
+- api_token: ""
+  opts:
+    description: |-
+      This is the API Key to access your account.
+
+      ## Where to get the Applivery Account API Key?
+
+      Sign in to your [Applivery.com](http://dashboard.applivery.com) account,
+      click on Developers menu option from the left side menu and copy it from the
+      Account API Key section.
+    is_required: true
+    summary: ""
+    title: Account API Key
+- app_id: ""
+  opts:
+    description: |-
+      This is the App Id that identifies your App in Applivery.com
+
+      ## Where to get the App Id?
+
+      Sign in to your [Applivery.com](http://dashboard.applivery.com) account,
+      click on Applications menu option from the left side menu, click on the desired App.
+      You'll find the App Id inside the (i) information block (written in red).
+    is_required: false
+    summary: ""
+    title: 'Applivery: App ID'
+- notes: Deployed with Bitrise Applivery.com iOS Deploy Step.
+  opts:
+    description: Additional build/release notes
+    summary: ""
+    title: Notes attached to the deploy
+- notify: "true"
+  opts:
+    description: This flag allows you to automatically notify your testers vía email.
+    is_required: true
+    summary: ""
+    title: Notify Testers?
+    value_options:
+    - "true"
+    - "false"
+- opts:
+    description: Comma-separated list of tags
+    is_required: false
+    summary: ""
+    title: (Optional) Comma-separated list of tags
+  tags: ""
+- opts:
+    description: Human readable version name for this build.
+    summary: ""
+    title: (Optional) Human readable version name
+  version_name: ""
+outputs:
+- APPLIVERY_DEPLOY_STATUS: null
+  opts:
+    description: ""
+    summary: ""
+    title: 'Deployment result: ''success'' or ''failed'''


### PR DESCRIPTION
Improved version including Bitrise team [feedback](https://github.com/bitrise-io/bitrise-steplib/pull/297)
- Dropped dependencies
- Removed all `is_dont_change_value: false`
- Removed all `is_expand: true`
- Removed all `is_required: true`
- Shortened Step ID: `applivery-ios`
- Three component SemVer version
- Dropped the additional indentation on description
- `run_if: .IsCI`
- Not print/log API TOKEN
- Improved Secret and Env Vars
- Added support for string Booleans
- Removed `os: ios` default value and moved hardcoded to` step.sh`