### PR TITLE
cordova-android 0.9.2

### DIFF
--- a/steps/cordova-android/0.9.2/step.yml
+++ b/steps/cordova-android/0.9.2/step.yml
@@ -1,0 +1,45 @@
+title: Cordova Android
+summary: This step allows you to build cordova-based Android projects.
+description: |-
+  The Cordova CLI is the main tool to use for the cross-platform workflow
+  described in the [Overview](https://cordova.apache.org/docs/en/latest/guide/overview/index.html).
+website: https://github.com/vgaidarji/steps-cordova-android
+source_code_url: https://github.com/vgaidarji/steps-cordova-android
+support_url: https://github.com/vgaidarji/steps-cordova-android/issues
+published_at: 2016-02-28T18:03:02.902627117+02:00
+source:
+  git: https://github.com/vgaidarji/steps-cordova-android.git
+  commit: 4a5490fb1d1ab65b77a6287742bf9d064d7b7258
+host_os_tags:
+- ubuntu
+project_type_tags:
+- android
+type_tags:
+- cordova
+- build
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+inputs:
+- cordova_command: build
+  opts:
+    description: Run `cordova --help` to check list of available commands.
+    is_required: true
+    title: Cordova command to run.
+- opts:
+    description: |
+      Choose which platform to build your dependencies for.
+    is_required: true
+    title: Platform to build.
+    value_options:
+    - android
+  platform_name: android
+- build_options: --verbose
+  opts:
+    description: |-
+      Options added to the end of the Cordova call.
+      You can use multiple options, separated by a space
+      character. For example: `--verbose`; `--debug`
+      `--release --buildConfig=..\myBuildConfig.json`
+    is_required: false
+    title: Additional options for `cordova` command


### PR DESCRIPTION
Corrected `platform_name` parameter name. 
Previously `step.yml` had parameter `platform`, but  `step.sh` was expecting `platform_name` parameter. 