### PR TITLE
install-react-native 0.1.0

### DIFF
--- a/steps/install-react-native/0.1.0/step.yml
+++ b/steps/install-react-native/0.1.0/step.yml
@@ -1,0 +1,37 @@
+title: Install React Native
+summary: Installs the `react-native-cli` command line tools.
+description: Installs the [React Native CLI npm package](https://www.npmjs.com/package/react-native-cli).
+website: https://github.com/vasarhelyia/steps-install-react-native
+source_code_url: https://github.com/vasarhelyia/steps-install-react-native
+support_url: https://github.com/vasarhelyia/steps-install-react-native/issues
+published_at: 2016-03-09T13:05:44.612977431+01:00
+source:
+  git: https://github.com/vasarhelyia/steps-install-react-native.git
+  commit: 6581075c27d05e8658c310c0a06a4ea90ca92cb9
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- react-native
+type_tags:
+- react-native
+deps:
+  brew:
+  - name: node
+  - name: watchman
+  - name: flow
+inputs:
+- opts:
+    description: |-
+      Version of the `react-native-cli` package to install.
+      If not specified, the latest version will be selected.
+      Check the logs for the available versions from this
+      package and specify the desired verion as `0.1.9` for example.
+    title: Version of the `react-native-cli` package to install
+  version: null
+- npm_options: null
+  opts:
+    description: |-
+      Options are added to `npm install`. `-g` (global) option is set by default.
+      You can use multiple options, separated by a space
+      character, for example `-dd -ll`
+    title: Additional options when installing React Native CLI with `npm install`


### PR DESCRIPTION
Initial release.

Step installs `react-native-cli` globally. 

Inputs:

- `version`
- `npm_options`