### PR TITLE
react-native-bundle 0.1.0

### DIFF
--- a/steps/react-native-bundle/0.1.0/step.yml
+++ b/steps/react-native-bundle/0.1.0/step.yml
@@ -1,0 +1,64 @@
+title: React Native bundle
+summary: Bundles your React Native app.
+description: Bundles your React Native app.
+website: https://github.com/vasarhelyia/steps-react-native-bundle
+source_code_url: https://github.com/vasarhelyia/steps-react-native-bundle
+support_url: https://github.com/vasarhelyia/steps-react-native-bundle/issues
+published_at: 2016-03-09T13:08:37.017266908+01:00
+source:
+  git: https://github.com/vasarhelyia/steps-react-native-bundle.git
+  commit: e46d467f46f5d0da43e36b7f49c6c56490a5709c
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- react-native
+type_tags:
+- react-native
+deps:
+  brew:
+  - name: node
+inputs:
+- opts:
+    description: Specify either `ios`, or `android` as platform for the bundler.
+    is_required: true
+    title: Bundle platform
+    value_options:
+    - ios
+    - android
+  platform: ios
+- dev: "false"
+  opts:
+    description: Set DEV flag.
+    title: DEV flag
+    value_options:
+    - "true"
+    - "false"
+- minify: "false"
+  opts:
+    description: Minify js bundle.
+    title: Minification
+    value_options:
+    - "true"
+    - "false"
+- opts:
+    description: Add another root(s) to be used in bundling in this project.
+    title: Root
+  root: null
+- assetRoots: null
+  opts:
+    description: Specify the root directories of app assets.
+    title: Asset root directories
+- opts:
+    description: Specify the output file.
+    title: Output file
+  out: null
+- opts:
+    description: Specify the bundle file URL.
+    title: Bundle file URL
+  url: null
+- options: null
+  opts:
+    description: |-
+      Options are added to `react-native bundle`. You can use multiple options, separated
+      by a space character.
+    title: Additional options for running `react-native bundle`


### PR DESCRIPTION
Initial release.

Runs `react-native bundle`

Options:

- `platform` specify the platform(android/ios)
- `--dev` sets DEV flag to true
- `--minify` minify js bundle
- `--root` add another root(s) to be used in bundling in this project
- `--assetRoots` specify the root directories of app assets
- `--out` specify the output file
- `--url` specify the bundle file url
- `options` any additional options separated by a space.