### PR TITLE
Add new step: xcode-project-info 1.0.0

### DIFF
--- a/steps/xcode-project-info/1.0.0/step.yml
+++ b/steps/xcode-project-info/1.0.0/step.yml
@@ -1,0 +1,36 @@
+title: Xcode Project Info
+summary: Extracts version and build number to environment variables.
+description: |-
+  This step will simply read version and build number from given `Info.plist` path,
+  then export those to **APP_VERSION** and **APP_BUILD** environment variables.
+
+  After this you can use these variables in other steps (ex. sending message on Slack).
+website: https://github.com/tadija/bitrise-step-xcode-project-info
+source_code_url: https://github.com/tadija/bitrise-step-xcode-project-info
+support_url: https://github.com/tadija/bitrise-step-xcode-project-info/issues
+published_at: 2016-04-21T17:01:30.388212516+02:00
+source:
+  git: https://github.com/tadija/bitrise-step-xcode-project-info.git
+  commit: 68f23a7580d1a1352c9d9617b3a7abccb4909186
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- script
+dependencies:
+- manager: brew
+  name: git
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- info_plist_path: Info.plist
+  opts:
+    is_dont_change_value: true
+    is_expand: true
+    is_required: true
+    summary: Path to project's Info.plist file.
+    title: Info.plist file path
+    value_options: []


### PR DESCRIPTION
Hello Bitrise,

I've made this step according to our talk in https://bitrise.uservoice.com/forums/235233-general/suggestions/11312937-version-and-build-number-as-environment-variables

I hope everything's fine, it seems to work in my local and 'remote' tests.

Cheers,
// T