### PR TITLE
nvm 0.1.0

### DIFF
--- a/steps/nvm/0.1.0/step.yml
+++ b/steps/nvm/0.1.0/step.yml
@@ -1,0 +1,37 @@
+title: NVM
+summary: Install NVM and select Node version
+description: |
+  Install NVM and select Node version
+  NVM = Node Version Manager - Simple bash script to manage multiple active node.js versions
+  See https://github.com/creationix/nvm
+website: https://github.com/almouro/bitrise-nvm-step
+source_code_url: https://github.com/almouro/bitrise-nvm-step
+support_url: https://github.com/almouro/bitrise-nvm-step/issues
+published_at: 2016-07-02T22:15:30.551754569+02:00
+source:
+  git: https://github.com/Almouro/bitrise-nvm-step.git
+  commit: 39aa1b7d154d4498b16a5eb6a0f9d13bc479d62c
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- script
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+inputs:
+- nvm_version: v0.31.0
+  opts:
+    description: |
+      NVM version to be installed
+    is_expand: false
+    is_required: true
+    title: NVM Version
+- node_version: 4.4.2
+  opts:
+    description: |
+      Node version to be installed
+    is_expand: false
+    is_required: true
+    title: Node version


### PR DESCRIPTION
Hi guys,

I've been using Bitrise for a few weeks now and it works great! :)
For npm projects like `react-native`, it's often nice to be able to exactly select the node version. This is exactly what [nvm](https://github.com/creationix/nvm) does!

I wanted to try it on `Bitrise.io`, so I set my steplib as a custom lib source to then run this step:
```
---
format_version: 1.2.0
default_step_lib_source: https://github.com/almouro/bitrise-steplib.git
trigger_map:
- pattern: "*"
  is_pull_request_allowed: true
  workflow: primary
workflows:
  primary:
    steps:
    - nvm@0.1.0: {}
app:
  envs:
  - opts:
      is_expand: false
    BITRISE_PROJECT_PATH: ios-simple-objc/ios-simple-objc.xcodeproj
  - opts:
      is_expand: false
    BITRISE_SCHEME: ios-simple-objc
```
It runs great, but the UI workflow editor will not work, saying *There’s an issue in your bitrise.yml configuration. You have to fix it before you could use the UI editor again. 
Error: Cannot read property 'versions' of undefined.*
Any idea why? First time I create a step, sorry if I missed something! :[

### New Pull Request Checklist

- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `stepman audit --step-yml ./step.yml` (in the step's repository - note, `stepman` is part of the Bitrise CLI, you don't have to install it separately)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

