### PR TITLE
aws-device-farm-file-deploy 0.0.1

### DIFF
--- a/steps/aws-device-farm-file-deploy/0.0.1/step.yml
+++ b/steps/aws-device-farm-file-deploy/0.0.1/step.yml
@@ -1,0 +1,70 @@
+title: Amazon Device Farm File Deploy
+summary: Amazon Device Farm File Deploy
+description: |-
+  Uploads file (i.e. test package, app data, etc.) to device farm
+
+  This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/)
+website: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy
+source_code_url: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy
+support_url: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy/issues
+published_at: 2016-09-21T15:09:57.928508568-07:00
+source:
+  git: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy.git
+  commit: 10505476e1a0dcf4ab004c71c147daba89e9fd9d
+host_os_tags:
+- linux
+- osx-10.9
+- osx-10.10
+type_tags:
+- test
+- amazon
+- device-farm
+deps:
+  brew:
+  - name: awscli
+  apt_get:
+  - name: awscli
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- access_key_id: ""
+  opts:
+    description: ""
+    is_required: true
+    summary: ""
+    title: AWS Access Key
+- opts:
+    description: ""
+    is_required: true
+    summary: ""
+    title: AWS Secret Key
+  secret_access_key: ""
+- device_farm_project: ""
+  opts:
+    description: Project ARNs can be obtained using the AWS CLI 'devicefarm list-projects'
+      command.
+    is_required: true
+    summary: ""
+    title: Device Farm Project ARN
+- opts:
+    description: Path of file to upload. If this is a test package, aws-device-farm-runner
+      can be configured to use the latest package with this name.
+    is_required: true
+    summary: ""
+    title: Upload File Path
+  upload_file_path: ""
+- opts:
+    description: ex. APPIUM_PYTHON_TEST_PACKAGE. See http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Upload.html#devicefarm-Type-Upload-type
+    is_required: true
+    summary: ""
+    title: Upload Type
+  upload_type: ""
+- aws_region: ""
+  opts:
+    description: |
+      If you want to specify a different AWS region. Leave
+      empty to use the default config/env setting.
+    summary: ""
+    title: AWS Region


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
 - Note: This test requires additional configuration to pass:
   1. `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` must be set in `.bitrise.secrets.yml`
    1. An Amazon device farm project must be set up in the target region, and its ARN must be specified in the `device_farm_project` input (see `step.yml` for more info on obtaining the ARN)
    1. `upload_file_path` input must be set to the path of any local file
- [ ] I did run `stepman audit --step-yml ./step.yml` (in the step's repository - note, `stepman` is part of the Bitrise CLI, you don't have to install it separately)
  - I was unable to locate the `stepman` tool on my `PATH` even though `bitrise` is installed and works OK.
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

