### PR TITLE
applivery-ios 0.2.1

### DIFF
--- a/steps/applivery-ios/0.2.1/step.yml
+++ b/steps/applivery-ios/0.2.1/step.yml
@@ -1,0 +1,103 @@
+title: Applivery.com iOS Deploy
+summary: Deploy your awesome iOS Application to Applivery.com
+description: |-
+  Deploy an iOS application to [Applivery](http://www.applivery.com),
+  add notes and notify testers.
+
+  Register a Applivery account at [http://www.applivery..com/](http://www.applivery.com)
+  and create an App to utilize this step.
+
+  You also need to get your *Account API Key* for you account and the *App Id* for the app.
+website: https://github.com/applivery/steps-applivery-ios-deploy
+source_code_url: https://github.com/applivery/steps-applivery-ios-deploy
+support_url: https://github.com/applivery/steps-applivery-ios-deploy/issues
+published_at: 2017-01-04T14:02:04.895044503+01:00
+source:
+  git: https://github.com/applivery/steps-applivery-ios-deploy.git
+  commit: d26536b4a5f2f148058aaf9623dc5c52c791a477
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- deploy
+- Applivery
+- iOS
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: .IsCI
+inputs:
+- ipa_path: $BITRISE_IPA_PATH
+  opts:
+    description: ""
+    is_required: true
+    summary: ""
+    title: IPA file path
+- api_token: $APPLIVERY_API_TOKEN
+  opts:
+    description: |-
+      This is the API Key to access your account.
+
+      ## Where to get the Applivery Account API Key?
+
+      Sign in to your [Applivery.com](http://dashboard.applivery.com) account,
+      click on Developers menu option from the left side menu and copy it from the
+      Account API Key section.
+    is_required: true
+    summary: ""
+    title: Account API Key
+- app_id: $APPLIVERY_APP_ID
+  opts:
+    description: |-
+      This is the App Id that identifies your App in Applivery.com
+
+      ## Where to get the App Id?
+
+      Sign in to your [Applivery.com](http://dashboard.applivery.com) account,
+      click on Applications menu option from the left side menu, click on the desired App.
+      You'll find the App Id inside the (i) information block (written in red).
+    is_required: false
+    summary: ""
+    title: 'Applivery: App ID'
+- notes: Deployed with Bitrise Applivery.com iOS Deploy Step.
+  opts:
+    description: Additional build/release notes
+    summary: ""
+    title: Release notes
+- notify: "true"
+  opts:
+    description: This flag allows you to automatically notify your testers vía email.
+    is_required: true
+    summary: ""
+    title: Notify Testers?
+    value_options:
+    - "true"
+    - "false"
+- autoremove: "true"
+  opts:
+    description: Automatically remove the oldest build before uploading a new one
+      to prevent reaching your account limits.
+    is_required: false
+    summary: ""
+    title: (Optional) Automatically remove the oldest build?
+    value_options:
+    - "true"
+    - "false"
+- opts:
+    description: Comma-separated list of tags to easily identify the build
+    is_required: false
+    summary: ""
+    title: (Optional) Comma-separated list of tags
+  tags: ""
+- opts:
+    description: Human readable version name for this build.
+    summary: ""
+    title: (Optional) Human readable version name
+  version_name: ""
+outputs:
+- APPLIVERY_DEPLOY_STATUS: null
+  opts:
+    description: ""
+    summary: ""
+    title: 'Deployment result: ''success'' or ''failed'''


### PR DESCRIPTION
Added support for `autoremove` param that automatically removes the oldest build before uploading a new one to prevent reaching account limits. By default it's set to `true` for any automatic deployment system.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
