### PR TITLE
generate-text-file 0.0.1

### DIFF
--- a/steps/generate-text-file/0.0.1/step.yml
+++ b/steps/generate-text-file/0.0.1/step.yml
@@ -1,0 +1,45 @@
+title: Generate Text File
+summary: Dynamically generate a text file
+description: |-
+  This step lets you generate a dynamic text file which can use any environment
+  variables. The path of the file will be made available as
+  `$GENERATED_TEXT_FILE_PATH`. This script can e.g. be used to generate the Play
+  Store's "What's New" file based on the Git commit message.
+website: https://github.com/nicolas-fricke/bitrise-step-generate-text-file
+source_code_url: https://github.com/nicolas-fricke/bitrise-step-generate-text-file
+support_url: https://github.com/nicolas-fricke/bitrise-step-generate-text-file/issues
+published_at: 2017-02-10T13:14:04.386721078+01:00
+source:
+  git: https://github.com/nicolas-fricke/bitrise-step-generate-text-file.git
+  commit: 1dd81d6acaf45388a446f85427cb89abdfb64726
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- android
+- xamarin
+type_tags:
+- script
+- file
+- versioning
+- build
+- utils
+- android
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- file_name: generated_text_file.txt
+  opts:
+    is_required: true
+    title: File Name
+- file_content: null
+  opts:
+    is_expand: true
+    is_required: true
+    summary: Add content for the text file here. You can also use all ENV variables.
+    title: Content of the text file
+outputs:
+- GENERATED_TEXT_FILE_PATH: null
+  opts:
+    title: Path to the generated text file


### PR DESCRIPTION
This step allows users to create a generic text file they can use further down in the process. This is useful for e.g. creating a _What's New_ message for the Play Store deploy step based on the Git commit messages.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
