### PR TITLE
wait-for-android-emulator 1.0.0

### DIFF
--- a/steps/wait-for-android-emulator/1.0.0/step.yml
+++ b/steps/wait-for-android-emulator/1.0.0/step.yml
@@ -1,0 +1,49 @@
+title: Wait for Android emulator
+summary: Wait for the emulator to finish boot
+description: |-
+  If your workflow contains `start-android-emulator` step,
+  and you've set `wait_for_boot` param to false, use this step to check
+  if android emulator is booted or wait for finishing boot.
+website: https://github.com/bitrise-steplib/steps-wait-for-android-emulator
+source_code_url: https://github.com/bitrise-steplib/steps-wait-for-android-emulator
+support_url: https://github.com/bitrise-steplib/steps-wait-for-android-emulator/issues
+published_at: 2017-03-22T15:26:02.122894843+01:00
+source:
+  git: https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git
+  commit: db746a6681bb14ef2e9aca5d7a97eb45c160a8cd
+host_os_tags:
+- ubuntu
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/steps-wait-for-android-emulator
+deps:
+  brew:
+  - name: go
+  apt_get:
+  - name: golang
+    bin_name: go
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+inputs:
+- emulator_serial: $BITRISE_EMULATOR_SERIAL
+  opts:
+    description: |
+      Emulator with the given serial will be checked if booted, or wait for it to boot.
+    is_required: true
+    summary: Emulator serial to check
+    title: Emulator serial
+- boot_timeout: "180"
+  opts:
+    description: |
+      Maximum time to wait for emulator to boot.
+    is_required: true
+    summary: Maximum time to wait for emulator to boot
+    title: Waiting timeout (secs)
+- android_home: $ANDROID_HOME
+  opts:
+    description: Android sdk path
+    is_required: true
+    title: Android sdk path


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
