### PR TITLE
Update xcode-test docs

### DIFF
--- a/steps/xcode-test/1.18.7/step.yml
+++ b/steps/xcode-test/1.18.7/step.yml
@@ -158,8 +158,7 @@ inputs:
         -project\-workspace PROJECT.xcodeproj\WORKSPACE.xcworkspace
         -scheme SCHEME
         build test
-        -destination platform=PLATFORM Simulator,name=NAME,OS=VERSION
-        -derivedDataPath DERIVED_DATA_PATH`
+        -destination platform=PLATFORM Simulator,name=NAME,OS=VERSION`
 
       In case of `generate_code_coverage_files: "yes"`
       `xcodebuild` gets two additional flags:


### PR DESCRIPTION
-derivedData $DERIVED_DATA isn't actually being added to the default `xcodebuild` command, which was a surprise for me when I added `DERIVED_DATA` as an env variable, but the actual path didn't change.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
