### PR TITLE
diawi-upload 0.0.1

### DIFF
--- a/steps/diawi-upload/0.0.1/step.yml
+++ b/steps/diawi-upload/0.0.1/step.yml
@@ -1,0 +1,56 @@
+title: Diawi Upload
+summary: |
+  Upload an ipa/apk/zip to Diawi
+description: |
+  Upload an ipa/apk/zip to Diawi
+website: https://github.com/deanWombourne/bitrise-step-diawi-upload
+source_code_url: https://github.com/deanWombourne/bitrise-step-diawi-upload
+support_url: https://github.com/deanWombourne/bitrise-step-diawi-upload/issues
+published_at: 2017-11-18T19:06:47.494135Z
+source:
+  git: https://github.com/deanWombourne/bitrise-step-diawi-upload.git
+  commit: 23f726706177c082f379896ed353521696a720a9
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: npm
+  apt_get:
+  - name: npm
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      The API token for Diawi.
+
+      It's free to sign up and get one, just go here: https://dashboard.diawi.com/signup.
+      You create an api token in the profile tab.
+    is_expand: true
+    is_required: true
+    summary: Diawi API token
+    title: API token
+  token: $DIAWI_TOKEN
+- filename: $BITRISE_IPA_PATH
+  opts:
+    description: |
+      The path to the file to upload - defaults to an IPA created by a bitrise archive step
+    is_expand: true
+    is_required: true
+    summary: The path to the file to upload
+    title: ipa/akp/zip file path
+outputs:
+- DIAWI_UPLOAD_URL: null
+  opts:
+    description: |
+      The URL of the uploaded file
+    summary: The URL of the uploaded file
+    title: The URL of the uploaded file


### PR DESCRIPTION
Hi,

This is a tiny step which just formalises loading the diawi npm module, and then using it to upload an ipa/apk/zip to Diawi for distribution (https://www.diawi.com).

This is the first time I've done this, so let me know if you need me to change anything :)


### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
