### PR TITLE
bitrise-step-remote-gist-bash-script-runner 1.0.1

### DIFF
--- a/steps/bitrise-step-remote-gist-bash-script-runner/1.0.1/step.yml
+++ b/steps/bitrise-step-remote-gist-bash-script-runner/1.0.1/step.yml
@@ -1,0 +1,36 @@
+title: Remote Gist Bash Script Runner
+summary: |
+  Downloads the content of the given Github Gist and runs it as a bash script.
+description: |
+  Downloads the content of the given Github Gist and runs it as a bash script.
+website: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner
+source_code_url: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner
+support_url: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner/issues
+published_at: 2018-01-29T23:42:59.981146977-06:00
+source:
+  git: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner.git
+  commit: 18a9958726866ac4432314564fb7abfb73ca26f9
+host_os_tags:
+- osx-10.9
+- osx-10.10
+type_tags:
+- script
+- bash
+- runner
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- gist_url: ""
+  opts:
+    description: |
+      URL of a Github Gist that contains a valid bash script. (The main Gist URL, *not* the *raw* Gist URL.)
+    is_required: true
+    title: Gist URL
+- exit_on_failure: "1"
+  opts:
+    description: |
+      Gists can contain more than one file. If true (1), the step will exit with failure if any of the remote gist files fail to load. If false (0), subsequent gist files will attempt to load, even if previous ones fail. Defaults to true (1).
+    is_required: true
+    title: Exit if remote script fails to load


### PR DESCRIPTION
Please review in conjunction with PR 1365

This step builds on the concept of [running remote bash scripts](https://github.com/bitrise-io/steps-remote-script-runner). However, this step is tailored specifically for running bash scripts from Github's code snippet system, [Gist](https://gist.github.com/). Whereas the basic bash script runner relies on a URL that links directly to a raw bash script, this step will attempt to run all files in a given Gist. This is convenient because you only need to provide the basic Gist URL, as opposed to the raw Gist URL(s), which changes each time your Gist content changes.This step automatically retrieves all the raw URLs associated with a Gist and runs them each in sequence. No more copying and pasting raw URLs into your remote bash script runner step; simply provide the main Gist URL, and this step does all the heavy lifting.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
