### PR TITLE
bitrise-step-remote-gist-bash-script-runner 1.0.7

### DIFF
--- a/steps/bitrise-step-remote-gist-bash-script-runner/1.0.7/step.yml
+++ b/steps/bitrise-step-remote-gist-bash-script-runner/1.0.7/step.yml
@@ -1,0 +1,39 @@
+title: Remote Gist Bash Script Runner
+summary: |
+  Downloads the content of the given Github Gist and runs it as a bash script.
+description: |
+  Downloads the content of the given Github Gist and runs it as a bash script.
+website: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner
+source_code_url: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner
+support_url: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner/issues
+published_at: 2018-01-31T14:33:39.65758853-06:00
+source:
+  git: https://github.com/jsauve/bitrise-step-remote-gist-bash-script-runner.git
+  commit: 9fb82a7ff54bbac36a7b32027fe1608a4d7e51f9
+host_os_tags:
+- osx-10.9
+- osx-10.10
+type_tags:
+- script
+- bash
+- runner
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- gist_url: ""
+  opts:
+    description: |
+      URL of a Github Gist that contains valid bash scripts(s). (A main Gist URL, *not* a _raw_ Gist URL.)
+    is_required: true
+    title: Gist URL
+- exit_on_failure: "true"
+  opts:
+    description: |
+      Defaults to *true*. If *true*, the step will exit with if any of the remote gist files fail to load or return a failure code (exit > 0). If *false*, subsequent gist files will attempt to load, even if previous ones fail. Note that Gists can contain more than one file.
+    is_required: true
+    title: Exit this step if any remote scripts fail
+    value_options:
+    - "true"
+    - "false"


### PR DESCRIPTION
ONE...MORE...PR...

Sorry, I've been iterating pretty quickly on this step and I think I finally got it pretty solid. There were some things about the step's bitrise.yml that I didn't understand before. Plus, I had originally copied the regular remote bash runner step files, so my format_version was 1 instead of 4. I also made one of the params a drop-down instead of a field.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
