### PR TITLE
bitrise-step-update-android-manifest 1.0.0

### DIFF
--- a/steps/bitrise-step-update-android-manifest/1.0.0/step.yml
+++ b/steps/bitrise-step-update-android-manifest/1.0.0/step.yml
@@ -1,0 +1,75 @@
+title: bitrise-step-update-android-manifest
+summary: |
+  Sets values in AndroidManifest.xml
+description: |
+  Sets the package, label, android:versionCode, and android:versionName attributes in AndroidManifest.xml
+website: https://github.com/jsauve/bitrise-step-bitrise-step-update-android-manifest
+source_code_url: https://github.com/jsauve/bitrise-step-bitrise-step-update-android-manifest
+support_url: https://github.com/jsauve/bitrise-step-bitrise-step-update-android-manifest/issues
+published_at: 2018-01-31T17:24:35.15690568-06:00
+source:
+  git: https://github.com/jsauve/bitrise-step-update-android-manifest.git
+  commit: 7b6007d634d66e1a85250c6be8e23acd2c64dc8c
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: xmlstarlet
+  apt_get:
+  - name: xmlstarlet
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- android_manifest_path: null
+  opts:
+    description: |
+      "The path to the AndroidManifest.xml, including the filename. Example: MyAndroidApp/Properties/AndroidManifest.xml"
+    is_expand: true
+    is_required: true
+    summary: The path to the AndroidManifest.xml, including the filename
+    title: Android Manifest Path
+    value_options: []
+- opts:
+    description: |
+      "The package value. Example: com.organization.appname"
+    is_expand: true
+    is_required: false
+    summary: 'The app package identifier. Example: com.organization.appname'
+    title: App Package Identifier
+    value_options: []
+  package_identifier: null
+- app_label: null
+  opts:
+    description: |
+      "This is the label that accompanies the app icon."
+    is_expand: true
+    is_required: false
+    summary: The app label shown with the app icon
+    title: App Label
+    value_options: []
+- opts:
+    description: |
+      "The app version code. Example: 1"
+    is_expand: true
+    is_required: false
+    summary: 'The app version code. Example: 1'
+    title: App Version Code
+    value_options: []
+  version_code: null
+- opts:
+    description: |
+      "The app version name. Example: 1.0"
+    is_expand: true
+    is_required: false
+    summary: 'The app version name. Example: 1.0'
+    title: App Version Name
+    value_options: []
+  version_name: null


### PR DESCRIPTION
I didn't find a step in the library for Android that updates all of the following:
- `package` attribute of `<manifest>` tag
- `android:versionCode` attribute of `<manifest>` tag
- `android:versionName` attribute of `<manifest>` tag
- `android:label` attribute of `<manifest> ` -> `<application>` tag

So, I made one. It uses `xmlstarlet` to accomplish value replacement. It has some basic validation, like checking the input AndroidManifest.xml for existence, and includes a test that replaces values in a dummy manifest file.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
