### PR TITLE
bitrise-step-stamp-appicon-with-version-number 1.0.0

### DIFF
--- a/steps/bitrise-step-stamp-appicon-with-version-number/1.0.0/step.yml
+++ b/steps/bitrise-step-stamp-appicon-with-version-number/1.0.0/step.yml
@@ -9,7 +9,7 @@ support_url: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version
 published_at: !!timestamp 2018-04-04T16:50:55.395108202+03:00
 source:
   git: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number.git
-  commit: 69ab704371355dc5daa4ca1ee7a8c2bf03c43fd5
+  commit: 5c7c44df263ab5201f14dfcb7be2eeb95417bce0
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -22,12 +22,8 @@ toolkit:
     package_name: github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
 deps:
   brew:
-  - name: git
-  - name: wget
   - name: imagemagick
   apt_get:
-  - name: git
-  - name: wget
   - name: imagemagick
 is_requires_admin_user: false
 is_always_run: false

--- a/steps/bitrise-step-stamp-appicon-with-version-number/1.0.0/step.yml
+++ b/steps/bitrise-step-stamp-appicon-with-version-number/1.0.0/step.yml
@@ -1,0 +1,63 @@
+title: Stamp AppIcon with version number
+summary: |
+  This script will use ImageMagick to stamp the version number to all icons.
+description: |
+  Stamps version "version(build number)" to the bottom of the icon.
+website: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+source_code_url: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+support_url: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number/issues
+published_at: !!timestamp 2018-04-04T16:50:55.395108202+03:00
+source:
+  git: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number.git
+  commit: 69ab704371355dc5daa4ca1ee7a8c2bf03c43fd5
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- ios
+type_tags:
+- deploy
+toolkit:
+  go:
+    package_name: github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+deps:
+  brew:
+  - name: git
+  - name: wget
+  - name: imagemagick
+  apt_get:
+  - name: git
+  - name: wget
+  - name: imagemagick
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+run_if: "true"
+inputs:
+- opts:
+    description: |
+      Relative path to icons for example `Project/General.xcassets/AppIcon.appiconset`
+    is_expand: true
+    is_required: true
+    summary: Relative path to icons
+    title: Path to icons of the project
+    value_options: []
+  stamp_path_to_icons: null
+- opts:
+    description: |
+      Version number or string for example 0.1 or Dev
+    is_expand: true
+    is_required: true
+    summary: Version number or string
+    title: Version number or string
+    value_options: []
+  stamp_version: null
+- opts:
+    description: |
+      Build number to stamp on the icon. Defaults to BITRISE_BUILD_NUMBER
+    is_expand: true
+    is_required: true
+    summary: Build number to stamp on the icon
+    title: Build number to stamp on the icon
+    value_options: []
+  stamp_build_number: $BITRISE_BUILD_NUMBER


### PR DESCRIPTION
Hi, I made a step that will use imagemagick to stamp a "version(build)" banner to iOS app icon.

### New Pull Request Checklist

- [x ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
