### PR TITLE
Publish a step that allows the user to re-install the bundler gem based on a Gemfile.lock

### DIFF
--- a/steps/install-bundler/1.0.1/step.yml
+++ b/steps/install-bundler/1.0.1/step.yml
@@ -1,0 +1,31 @@
+title: Install specific bundler version
+summary: This step allows you to uninstall the system bundler version, and match the
+  one in your Gemfile.
+description: This step allows you to uninstall the system bundler version, and match
+  the one in your Gemfile..
+website: https://github.com/FutureWorkshops/bitrise-step-install-bundler
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-install-bundler
+published_at: 2019-02-06T18:58:36.415567+01:00
+source:
+  git: https://github.com/FutureWorkshops/bitrise-step-install-bundler.git
+  commit: a85500a815476ed06008d301563cddcb1ca4ad7d
+host_os_tags:
+- osx-10.10
+- osx-10.9
+project_type_tags:
+- ios
+- xamarin
+type_tags:
+- xcode
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- gemfile_path: ./Gemfile.lock
+  opts:
+    description: Gemfile lock that will be used to base the bundler version
+    is_expand: true
+    is_required: true
+    summary: Gemfile lock that will be used to base the bundler version
+    title: Path to the Gemfile lock


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=1899)

This step basically checks if the current machine bundler gem is able to operate in the project. If the check fails, it looks for a Gemfile.lock to extract the Bundled version, and install that version in the machine.

This was created to [fix a problem](https://discuss.bitrise.io/t/machine-unable-to-use-update-bundler-2-0/7862/5?u=fwigor) when running projects bundled with bundle version 2.x on macOS machines.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)