### PR TITLE
magicpod-ui-test 0.1.1

### DIFF
--- a/steps/magicpod-ui-test/0.1.1/step.yml
+++ b/steps/magicpod-ui-test/0.1.1/step.yml
@@ -1,0 +1,238 @@
+title: Magic Pod UI test
+summary: |
+  Magic Pod UI test step
+description: |
+  Magic Pod UI test step
+website: https://github.com/magic-Pod/bitrise-step-magicpod-uitest
+source_code_url: https://github.com/magic-Pod/bitrise-step-magicpod-uitest
+support_url: https://github.com/magic-Pod/bitrise-step-magicpod-uitest/issues
+published_at: 2019-03-12T16:10:09.954708+09:00
+source:
+  git: https://github.com/magic-Pod/bitrise-step-magicpod-uitest.git
+  commit: 0e4d24b2900588e51c261d755050a2fa6c187f35
+project_type_tags:
+- ios
+- android
+type_tags:
+- test
+toolkit:
+  go:
+    package_name: github.com/magic-Pod/bitrise-step-magicpod-uitest
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- magic_pod_api_token: null
+  opts:
+    description: "Access token to use Magic Pod Web API.\nKey: Arbitrary new Secret
+      Env name like MAGIC_POD_API_TOKEN\nValue: API token copied from https://magic-pod.com/accounts/api-token/. "
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: Magic Pod API token
+- opts:
+    description: |-
+      Organization name in Magic Pod.
+      Please be sured to use **organization name**, not **display name**.
+    is_expand: true
+    is_required: true
+    title: Organization name
+  organization_name: null
+- opts:
+    description: |-
+      Project name in Magic Pod.
+      Please be sured to use **project name**, not **display name**.
+    is_expand: true
+    is_required: true
+    title: Project name
+  project_name: null
+- environment: Magic Pod
+  opts:
+    description: |-
+      Environment (cloud service) on which you want to execute your tests.
+      Each environment has its own limitation of OS/devices.  Please refer to project batch runs page for available choices.
+    is_expand: true
+    is_required: true
+    title: Environment
+    value_options:
+    - Magic Pod
+    - Remote TestKit
+- external_service_token: null
+  opts:
+    description: |-
+      Access token to use external cloud services (ex. Remote TestKit) for testing.
+      Required when you have selected **other than Magic Pod** for _Environment_.
+    is_expand: true
+    is_sensitive: true
+    title: External service token
+- opts:
+    description: "Currently you can select only \n\n* _iOS_ for Magic Pod cloud service.\n*
+      _Android_ for Remote TestKit."
+    is_expand: true
+    is_required: true
+    title: OS
+    value_options:
+    - iOS
+    - Android
+  os: iOS
+- device_type: Simulator
+  opts:
+    description: |-
+      Currently you can select only
+
+      * _Simulator_ for Magic Pod cloud service.
+      * _Real Device_ for Remote TestKit.
+    is_expand: true
+    is_required: true
+    title: Device type
+    value_options:
+    - Simulator
+    - Emulator
+    - Real Device
+- opts:
+    description: "Currently you can select only \n\n* _12.1_ for Magic Pod cloud service."
+    is_expand: true
+    is_required: true
+    title: Version
+  version: "12.1"
+- model: iPhone 8
+  opts:
+    description: |-
+      Currently you can select only
+
+      * _iPhone 8_ for Magic Pod cloud service.
+      * For Remote TestKit, please refer to model list on https://appkitbox.com/testkit/devicelist/.
+    is_expand: true
+    is_required: true
+    title: Model
+- app_type: App file (cloud upload)
+  opts:
+    description: |-
+      Specify how you submit your app to the cloud.
+
+      * When you select _App file (cloud upload)_, then fill in _App path_ field below.
+      * When you select _App file (URL)_, then fill in _App URL_ field below.
+      * When you select _Installed app_, then fill in _Bundle ID_ field for iOS, or _App package_ and _App activity_ for Android.
+    is_expand: true
+    is_required: true
+    title: App type
+    value_options:
+    - App file (cloud upload)
+    - App file (URL)
+    - Installed app
+- app_path: $BITRISE_APP_DIR_PATH
+  opts:
+    description: "Required when you have selected _App file (cloud upload)_ for _App
+      type_.\n\n* *Warning: The file of the specified path is uploaded to Magic Pod
+      cloud and can be seen by project members.*\n* For iOS simulator testing, specify
+      the directory _xx.app_ so that included files are automatically ziped into one
+      file before uploading. "
+    is_expand: true
+    title: App path
+- app_url: null
+  opts:
+    description: Required when you have selected _App file (URL)_ for _App type_.
+    is_expand: true
+    title: App URL
+- bundle_id: null
+  opts:
+    description: |-
+      Required when you have selected _iOS_ for _OS_ and _Installed_ for _App type_.
+
+      * ex) `com.apple.Preferences`
+    is_expand: true
+    title: Bundle ID
+- app_package: null
+  opts:
+    description: |-
+      Required when you have selected _Android_ for _OS_ and _Installed_ for _App type_.
+
+      * ex) `com.android.settings`
+    is_expand: true
+    title: App package
+- app_activity: null
+  opts:
+    description: |-
+      Required when you have selected _Android_ for _OS_ and _Installed_ for _App type_.
+
+      * ex) `.Settings`
+    is_expand: true
+    title: App activity
+- opts:
+    description: |-
+      If set to true, this step waits until Magic Pod testing is completed and succeeds only when the test is successful.
+      Otherwise this step immediately exits with success.
+    title: Wait for result
+  wait_for_result: "true"
+- opts:
+    description: If _true_, the test result is sent to all project members by Magic
+      Pod.
+    is_required: true
+    title: Send mail
+    value_options:
+    - "true"
+    - "false"
+  send_mail: "true"
+- opts:
+    category: detail
+    description: |-
+      Each test in the project is executed at most the specified number of times when it failed.
+      Please set to 0 for no retry.
+    title: Retry count
+  retry_count: "0"
+- capture_type: Every step
+  opts:
+    category: detail
+    description: Specify how often you want to save captures of your app screen.
+    is_expand: true
+    is_required: true
+    title: Capture type
+    value_options:
+    - Every step
+    - Every UI transit
+    - Failure capture only
+- device_language: English
+  opts:
+    category: detail
+    is_expand: true
+    title: Device language
+    value_options:
+    - English
+    - Japanese
+- multi_lang_data: null
+  opts:
+    category: detail
+    description: |-
+      Required when you have Multi-lang data patterns for the project.
+      This feature is only for enterprise users.
+    is_expand: true
+    title: Multi-lang data pattern
+- base_url: https://magic-pod.com/api/v1.0
+  opts:
+    category: debug
+    description: Cannot be changed
+    is_dont_change_value: true
+    title: Magic Pod web API URL
+outputs:
+- MAGIC_POD_TEST_STATUS: null
+  opts:
+    summary: Status of batch test run. The value is either of 'succeeded', 'failed',
+      'aborted', 'running'.
+    title: MAGIC_POD_TEST_STATUS
+- MAGIC_POD_TEST_PASSED_COUNT: null
+  opts:
+    summary: The number of succeeded test cases in the batch run.
+    title: MAGIC_POD_TEST_PASSED_COUNT
+- MAGIC_POD_TEST_FAILED_COUNT: null
+  opts:
+    summary: The number of failed test cases in the batch run.
+    title: MAGIC_POD_TEST_FAILED_COUNT
+- MAGIC_POD_TEST_TOTAL_COUNT: null
+  opts:
+    summary: The number of total test cases in the batch run.
+    title: MAGIC_POD_TEST_TOTAL_COUNT
+- MAGIC_POD_TEST_URL: null
+  opts:
+    summary: URL of Magic Pod batch run page
+    title: MAGIC_POD_TEST_URL


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=1931)

Sorry for the frequency. Since there are several problems in the first version and we have changed our service's spec a little, we'd like to update the step definition.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
