### PR TITLE
applivery-ios 0.3.1

### DIFF
--- a/steps/applivery-ios/0.3.1/step.yml
+++ b/steps/applivery-ios/0.3.1/step.yml
@@ -1,0 +1,94 @@
+title: Applivery.com v3 iOS Deploy
+summary: Deploy your awesome iOS App to Applivery.com
+description: |-
+  Deploy an iOS application to [Applivery](http://www.applivery.com),
+  add notes and notify Collaborators and Employees.
+
+  Register a Applivery account at [http://www.applivery.com/](http://www.applivery.com)
+  and create an App to utilize this step.
+
+  You also need to get your *App Token* of your App that can be found under your App Settings.
+website: https://github.com/applivery/steps-applivery-ios-deploy
+source_code_url: https://github.com/applivery/steps-applivery-ios-deploy
+support_url: https://github.com/applivery/steps-applivery-ios-deploy/issues
+published_at: 2019-06-14T12:44:16.708514+02:00
+source:
+  git: https://github.com/applivery/steps-applivery-ios-deploy.git
+  commit: b820380e472fadb6702c677266ff77db22b6d5d5
+host_os_tags:
+- ubuntu
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- deploy
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: .IsCI
+inputs:
+- ipa_path: $BITRISE_IPA_PATH
+  opts:
+    description: ""
+    is_required: true
+    summary: ""
+    title: IPA file path
+- appToken: $APPLIVERY_APP_TOKEN
+  opts:
+    description: |-
+      This is your App Token
+
+      ## Where to get the Applivery Account API Key?
+
+      Sign in to your [Applivery](http://dashboard.applivery.io) account,
+      click on your App and the navigate to the Settings menu option. Scroll down to the Integrations section and click on New Token button to generate a new token. Then, copy & paste it here. [Read more](https://www.applivery.com/docs/rest-api/authentication/)
+    is_required: true
+    summary: ""
+    title: App Token
+- changelog: ""
+  opts:
+    description: Additional build/release notes or changelog attached to the deploy
+    summary: ""
+    title: (Optional) Changelog or release notes
+- notifyCollaborators: "true"
+  opts:
+    description: This flag allows you to automatically notify your project Collaborators
+      vía email.
+    is_required: true
+    summary: ""
+    title: Notify Collaborators?
+    value_options:
+    - "true"
+    - "false"
+- notifyEmployees: "true"
+  opts:
+    description: This flag allows you to automatically notify your project Employees
+      vía email.
+    is_required: true
+    summary: ""
+    title: Notify Employees?
+    value_options:
+    - "true"
+    - "false"
+- notifyMessage: ""
+  opts:
+    description: Notification message to be sent along with the email notification
+    summary: ""
+    title: (Optional) Notification message
+- opts:
+    description: Comma-separated list of tags to easily identify the build
+    is_required: false
+    summary: ""
+    title: (Optional) Comma-separated list of tags
+  tags: ""
+- opts:
+    description: Human readable version name for this build.
+    summary: ""
+    title: (Optional) Human readable version name
+  versionName: ""
+outputs:
+- APPLIVERY_DEPLOY_STATUS: null
+  opts:
+    description: ""
+    summary: ""
+    title: 'Deployment result: ''success'' or ''failed'''


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2018)

### Added
- Support to `BITRISE_CERTIFICATE_URL`
- Support to `BITRISE_CERTIFICATE_PASSPHRASE`

### Fixed
- Wrong `BITRISE_IPA_PATH` making it impossible to find a valid `.ipa` file to deploy

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
