### PR TITLE
browserstack-app-live-upload 1.0.0

### DIFF
--- a/steps/browserstack-app-live-upload/1.0.0/step.yml
+++ b/steps/browserstack-app-live-upload/1.0.0/step.yml
@@ -1,0 +1,58 @@
+title: Browserstack App Live Upload
+summary: |
+  Uploads your APK or IPA to Browserstack for interactive app testing.
+description: "Uploads your APK or IPA to Browserstack for interactive app testing.
+  \nYou can find your username and access key at https://www.browserstack.com/app-live/rest-api\n"
+website: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
+source_code_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
+support_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload/issues
+published_at: 2019-10-09T21:13:42.734529+01:00
+source:
+  git: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload.git
+  commit: fbbb2908a9d69b2ac5215468736b2b49ac7a3e25
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+- ios
+- android
+- xamarin
+- react-native
+- cordova
+- ionic
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- apk_ipa_filepath: null
+  opts:
+    description: |
+      The app file you want to upload to BrowserStack, usually $BITRISE\_APK\_PATH
+      or $BITRISE\_IPA\_PATH
+    is_expand: true
+    is_required: true
+    summary: Location of the IPA or APK that you want to upload.
+    title: Location of the IPA or APK
+- browserstack_username: null
+  opts:
+    description: |
+      The username you use to log into Browserstack
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: The username you use to log into Browserstack
+    title: Browserstack Username
+- browserstack_access_key: null
+  opts:
+    description: |
+      The access key for your Browserstack account.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: The access key for your Browserstack account.
+    title: Browserstack Access Key

--- a/steps/browserstack-app-live-upload/1.0.0/step.yml
+++ b/steps/browserstack-app-live-upload/1.0.0/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 source_code_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 support_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload/issues
-published_at: 2019-10-10T15:27:24.836501+01:00
+published_at: 2019-10-10T16:51:25.06298+01:00
 source:
   git: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload.git
-  commit: cbc8c2edc43f143b6ed26d49e7b7b4c4db1d51ed
+  commit: d7100a123466d55bae8f93d536bdd3c7be8a4dca
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04

--- a/steps/browserstack-app-live-upload/1.0.0/step.yml
+++ b/steps/browserstack-app-live-upload/1.0.0/step.yml
@@ -2,14 +2,14 @@ title: Browserstack App Live Upload
 summary: |
   Uploads your APK or IPA to Browserstack for interactive app testing.
 description: |
-  Uploads your APK or IPA to Browserstack for interactive app testing. You can find your username and access key at https://www.browserstack.com/app-live/rest-api
+  Uploads your APK or IPA to Browserstack for interactive app testing. You can find your username and access key at https://www.browserstack.com/accounts/settings
 website: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 source_code_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 support_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload/issues
-published_at: 2019-10-10T14:40:30.023377+01:00
+published_at: 2019-10-10T15:27:24.836501+01:00
 source:
   git: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload.git
-  commit: 132ca90b3c3bd18badac2ce69a4c36b8fbf43bfd
+  commit: cbc8c2edc43f143b6ed26d49e7b7b4c4db1d51ed
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04

--- a/steps/browserstack-app-live-upload/1.0.0/step.yml
+++ b/steps/browserstack-app-live-upload/1.0.0/step.yml
@@ -1,24 +1,26 @@
 title: Browserstack App Live Upload
 summary: |
   Uploads your APK or IPA to Browserstack for interactive app testing.
-description: "Uploads your APK or IPA to Browserstack for interactive app testing.
-  \nYou can find your username and access key at https://www.browserstack.com/app-live/rest-api\n"
+description: |
+  Uploads your APK or IPA to Browserstack for interactive app testing. You can find your username and access key at https://www.browserstack.com/app-live/rest-api
 website: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 source_code_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload
 support_url: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload/issues
-published_at: 2019-10-09T21:13:42.734529+01:00
+published_at: 2019-10-10T14:40:30.023377+01:00
 source:
   git: https://github.com/andrewmarmion/bitrise-step-browserstack-app-live-upload.git
-  commit: fbbb2908a9d69b2ac5215468736b2b49ac7a3e25
+  commit: 132ca90b3c3bd18badac2ce69a4c36b8fbf43bfd
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
+project_type_tags:
 - ios
 - android
 - xamarin
 - react-native
 - cordova
 - ionic
+- flutter
 type_tags:
 - deploy
 toolkit:
@@ -32,8 +34,7 @@ inputs:
 - apk_ipa_filepath: null
   opts:
     description: |
-      The app file you want to upload to BrowserStack, usually $BITRISE\_APK\_PATH
-      or $BITRISE\_IPA\_PATH
+      The app file you want to upload to BrowserStack, usually $BITRISE\_APK\_PATH or $BITRISE\_IPA\_PATH.
     is_expand: true
     is_required: true
     summary: Location of the IPA or APK that you want to upload.
@@ -41,11 +42,11 @@ inputs:
 - browserstack_username: null
   opts:
     description: |
-      The username you use to log into Browserstack
+      The username you use to log into Browserstack.
     is_expand: true
     is_required: true
     is_sensitive: true
-    summary: The username you use to log into Browserstack
+    summary: The username you use to log into Browserstack.
     title: Browserstack Username
 - browserstack_access_key: null
   opts:


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2168)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

It should be noted that this step is different from the [browserstack-upload](https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/browserstack-upload) step.  **browserstack-upload** uses the _app-automate_ Browserstack endpoint.

This step, **browserstack-app-live-upload**, uses Browserstack's _app-live_ endpoint. 