### PR TITLE
Discord message 0.0.2

### DIFF
--- a/steps/discord-message/0.0.1/step.yml
+++ b/steps/discord-message/0.0.1/step.yml
@@ -8,7 +8,7 @@ description: |
 website: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
 source_code_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
 support_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
-published_at: 2019-10-10T22:26:10.116317-03:00
+published_at: 2019-10-10T22:52:23.548749-03:00
 source:
   git: https://gitlab.com/lighthouseit/packages/bitrise-discord-message.git
   commit: efb70580af691fdaa4ac974fb70130721f46a31a

--- a/steps/discord-message/0.0.1/step.yml
+++ b/steps/discord-message/0.0.1/step.yml
@@ -1,0 +1,59 @@
+title: Send a Discord message
+summary: |
+  Send a [Discord](https://discordapp.com) message to a text channel
+description: |
+  Send a [Discord](https://discordapp.com) message to a text channel using Discord Webhooks
+
+  To find your text channel **webhook** visit: [https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token](https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token)
+website: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
+source_code_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
+support_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
+published_at: 2019-10-10T22:26:10.116317-03:00
+source:
+  git: https://gitlab.com/lighthouseit/packages/bitrise-discord-message.git
+  commit: efb70580af691fdaa4ac974fb70130721f46a31a
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+inputs:
+- is_debug_mode: "no"
+  opts:
+    description: |
+      Setep prints additional debug information if this option is enabled
+    title: Debug mode?
+    value_options:
+    - "yes"
+    - "no"
+- opts:
+    description: |
+      **Either webhook\_url with webhook token is required.**
+
+      To obtain the channel **Webhook** visit: https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token
+    is_required: true
+    is_sensitive: true
+    title: Discord channel Webhook URL
+  webhook_url: null
+- opts:
+    description: |-
+      If set, this step will set a specific status instead of reporting the current build status.
+
+      Can be one of auto, running, success, failed or aborted.
+      If you select `auto` the step will send `success` status if the current build status is success (no step failed previously)
+      and `failed` status if the build previously failed.
+    summary: ""
+    title: Set Specific Status
+    value_options:
+    - auto
+    - running
+    - success
+    - failed
+    - aborted
+  preset_status: auto

--- a/steps/discord-message/0.0.2/step.yml
+++ b/steps/discord-message/0.0.2/step.yml
@@ -1,0 +1,62 @@
+title: Send a Discord message
+summary: |
+  Send a [Discord](https://discordapp.com) message with the build status
+description: |
+  Send a [Discord](https://discordapp.com) message to a text channel with the build status using Discord Webhooks
+
+  To find your text channel **webhook** visit: [https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token](https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token)
+website: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
+source_code_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message
+support_url: https://gitlab.com/lighthouseit/packages/bitrise-discord-message/issues
+published_at: 2019-10-15T14:17:33.623289-03:00
+source:
+  git: https://gitlab.com/lighthouseit/packages/bitrise-discord-message.git
+  commit: 94ef4e833bf0bfd8209ff892f3bf49e89443c1a4
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+inputs:
+- opts:
+    description: |
+      **Webhook\_url with webhook token is required.**
+
+      To obtain the channel **Webhook** visit: https://github.com/Akizo96/de.isekaidev.discord.wbbBridge/wiki/How-to-get-Webhook-ID-&-Token
+    is_required: true
+    is_sensitive: true
+    title: Discord Webhook URL
+  webhook_url: null
+- mention_role: '@everyone'
+  opts:
+    description: The Discord role to be mentioned if a build failure
+    is_required: false
+    title: Mention Role
+- opts:
+    description: |-
+      If set, this step will set a specific status instead of reporting the current build status.
+
+      Can be one of auto, running, success, failed or aborted.
+      If you select `auto` the step will send `success` status if the current build status is success (no step failed previously)
+      and `failed` status if the build previously failed.
+    title: Set Specific Status
+    value_options:
+    - auto
+    - running
+    - success
+    - failed
+    - aborted
+  preset_status: auto
+- is_debug_mode: "no"
+  opts:
+    description: Step prints additional debug information if this option is enabled
+    title: Debug mode?
+    value_options:
+    - "yes"
+    - "no"


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2198)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

**Features**

- Added Step icon
- Allow users to change the Discord role that will be mentioned when a build failure