### PR TITLE
close-jira-tasks 1.0.0

### DIFF
--- a/steps/close-jira-tasks/1.0.0/step.yml
+++ b/steps/close-jira-tasks/1.0.0/step.yml
@@ -17,10 +17,10 @@ description: |
 website: https://github.com/orestesgaolin/bitrise-close-jira-tasks
 source_code_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks
 support_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks/issues
-published_at: 2019-10-17T21:14:44.722025+02:00
+published_at: 2019-10-17T21:18:50.355432+02:00
 source:
   git: https://github.com/orestesgaolin/bitrise-close-jira-tasks.git
-  commit: e405daeb7a99bf57c61378433a22b7ead17d003d
+  commit: a6efdb102ba4b70fa667268f8f66c85e1667edce
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -32,6 +32,7 @@ toolkit:
 deps:
   brew:
   - name: git
+  - name: jq
   apt_get:
   - name: git
   - name: jq

--- a/steps/close-jira-tasks/1.0.0/step.yml
+++ b/steps/close-jira-tasks/1.0.0/step.yml
@@ -17,10 +17,10 @@ description: |
 website: https://github.com/orestesgaolin/bitrise-close-jira-tasks
 source_code_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks
 support_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks/issues
-published_at: 2019-10-17T21:18:50.355432+02:00
+published_at: 2019-10-17T22:06:57.040904+02:00
 source:
   git: https://github.com/orestesgaolin/bitrise-close-jira-tasks.git
-  commit: a6efdb102ba4b70fa667268f8f66c85e1667edce
+  commit: d870ad85bb907c116429b2dada5324b0a5a8f6bc
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -63,6 +63,7 @@ inputs:
       You should use secret environment variable
     is_expand: true
     is_required: true
+    is_sensitive: true
     summary: Token used to authenticate to Jira
     title: Jira API token
 - from_status: Deploying

--- a/steps/close-jira-tasks/1.0.0/step.yml
+++ b/steps/close-jira-tasks/1.0.0/step.yml
@@ -1,0 +1,100 @@
+title: close-jira-tasks
+summary: |
+  Step moves Jira tasks from given initial state to target state if their ids are in git log
+description: |
+  Step searches Jira project for tasks that are in `from_status` (e.g. `Deploying`) state
+  and after successful build moves them to `to_status` (e.g. `Stabilization on QA`) state.
+
+  This is useful if you use smart commits in Jira, e.g. if your commit message
+  includes `TEST-123 #Do`.
+  This would cause the issue TEST-123 to transition according to `Do` keyword.
+
+  The step works for multiple issues mentioned in last 100 commits, so if
+  you finished multiple tasks it should move all of them to the `to_status` state
+  provided they are in `from_status` at the moment of execution.
+
+  The step can also add custom value to the custom field in the Jira issue e.g. version of the app.
+website: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks
+source_code_url: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks
+support_url: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks/issues
+published_at: 2019-10-17T17:14:04.666708+02:00
+source:
+  git: https://github.com/orestesgaolin/bitrise-close-jira-tasks.git
+  commit: 0388ec9069c55aefe74baeab8d312c2aaee2ca6e
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: wget
+  - name: jq
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- jira_project_name: ""
+  opts:
+    description: |
+      Description of this input.
+    is_expand: true
+    is_required: true
+    summary: Acronym used in Jira e.g. TEMP, GAS, TEST
+    title: Jira Project name
+- jira_url: ""
+  opts:
+    description: |
+      This can be e.g. https://company.atlassian.net
+    is_expand: true
+    is_required: true
+    summary: Base URL to company Jira
+    title: Jira Project URL
+- jira_token: $JIRA_TOKEN
+  opts:
+    description: |
+      You should use secret environment variable
+    is_expand: true
+    is_required: true
+    summary: Token used to authenticate to Jira
+    title: Jira API token
+- from_status: Deploying
+  opts:
+    description: |
+      Status of tasks which are closed by developer and are currently being dpeloyed (may be a column name in Jira)
+    is_expand: true
+    is_required: true
+    summary: Status of tasks which are closed by developer
+    title: Initial status
+- opts:
+    description: |
+      Status of tasks which were deployed successfully (may be a column name in Jira)
+    is_expand: true
+    is_required: true
+    summary: Status of tasks which were deployed successfully
+    title: Initial status
+  to_status: Stabilization on QA
+- custom_jira_field: ""
+  opts:
+    description: |
+      This should be in format `customfield_xxxxx`
+    is_expand: true
+    is_required: false
+    summary: Current version number will be set in this custom field of Jira issues
+    title: Custom field to update version number
+- opts:
+    description: |
+      You should use Bitrise env variable
+    is_expand: true
+    is_required: false
+    summary: Current version number will be set in `custom_jira_field` of Jira issues
+    title: App version
+  version: $BITRISE_BUILD_NUMBER

--- a/steps/close-jira-tasks/1.0.0/step.yml
+++ b/steps/close-jira-tasks/1.0.0/step.yml
@@ -14,13 +14,13 @@ description: |
   provided they are in `from_status` at the moment of execution.
 
   The step can also add custom value to the custom field in the Jira issue e.g. version of the app.
-website: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks
-source_code_url: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks
-support_url: https://github.com/orestesgaolin/bitrise-step-close-jira-tasks/issues
-published_at: 2019-10-17T17:14:04.666708+02:00
+website: https://github.com/orestesgaolin/bitrise-close-jira-tasks
+source_code_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks
+support_url: https://github.com/orestesgaolin/bitrise-close-jira-tasks/issues
+published_at: 2019-10-17T21:14:44.722025+02:00
 source:
   git: https://github.com/orestesgaolin/bitrise-close-jira-tasks.git
-  commit: 0388ec9069c55aefe74baeab8d312c2aaee2ca6e
+  commit: e405daeb7a99bf57c61378433a22b7ead17d003d
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -32,11 +32,9 @@ toolkit:
 deps:
   brew:
   - name: git
-  - name: wget
-  - name: jq
   apt_get:
   - name: git
-  - name: wget
+  - name: jq
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
@@ -45,11 +43,11 @@ inputs:
 - jira_project_name: ""
   opts:
     description: |
-      Description of this input.
+      This will be used by script to determine tasks ids in git log e.g. TEST-123
     is_expand: true
     is_required: true
     summary: Acronym used in Jira e.g. TEMP, GAS, TEST
-    title: Jira Project name
+    title: Jira project name
 - jira_url: ""
   opts:
     description: |
@@ -57,7 +55,7 @@ inputs:
     is_expand: true
     is_required: true
     summary: Base URL to company Jira
-    title: Jira Project URL
+    title: Jira project URL
 - jira_token: $JIRA_TOKEN
   opts:
     description: |


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2205)

Hi, this is step used in our organization to close some tasks in Jira project. It may be considered a bit too custom, but works well for us.

In order to run tests there are some preparations need.

- the `JIRA_TOKEN` variable must be set and correct
- `./_tmp` directory must be changed to a git repository with git log containing given [smart commit](https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html), e.g. with line `GAS-123`.
- `jira_url` must be changed to existing Jira account with existing `jira_project_name` project

I don't know how to make this tests reproducible and idempotent unfortunately.

### New Pull Request Checklist

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
