### PR TITLE
Appcenter app release 1.0.5

### DIFF
--- a/steps/appcenter-app-release/1.0.4/step.yml
+++ b/steps/appcenter-app-release/1.0.4/step.yml
@@ -1,0 +1,84 @@
+title: AppCenter App Release
+summary: |
+  Release an application on Microsoft AppCenter
+description: |
+  Release an application on Microsoft AppCenter
+website: https://github.com/fileformat/bitrise-step-appcenter-app-release
+source_code_url: https://github.com/fileformat/bitrise-step-appcenter-app-release
+support_url: https://github.com/fileformat/bitrise-step-appcenter-app-release/issues
+published_at: 2019-11-14T14:29:07.683519-05:00
+source:
+  git: https://github.com/fileformat/bitrise-step-appcenter-app-release.git
+  commit: 53de7d586a5118ba8931c7d72f87fdfd059ec627
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: jq
+  - name: curl
+  apt_get:
+  - name: jq
+  - name: curl
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- appcenter_api_token: $APPCENTER_API_TOKEN
+  opts:
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: AppCenter API Token
+- appcenter_name: $APPCENTER_NAME
+  opts:
+    is_expand: true
+    is_required: true
+    title: AppCenter Application Name
+- appcenter_org: $APPCENTER_ORG
+  opts:
+    is_expand: true
+    is_required: true
+    title: AppCenter Organization
+- artifact_path: $ARTIFACT_PATH
+  opts:
+    is_expand: true
+    is_required: true
+    title: path to the built application file (.ipa or .apk)
+- distribution_groups: $DISTRIBUTION_GROUPS
+  opts:
+    description: Groups should be comma separated e.g. group1, group2. If not specified,
+      artifact will be sent to all distribution groups
+    is_expand: true
+    is_required: false
+    title: AppCenter distribution groups
+- mandatory_update: $MANDATORY_UPDATE
+  opts:
+    description: Whether this release is a mandatory update (default = false)
+    is_expand: true
+    is_required: false
+    title: AppCenter Mandatory Update flag
+- notify_testers: $NOTIFY_TESTERS
+  opts:
+    is_expand: true
+    is_required: false
+    summary: Do you want to notify testers of a new release (default = true)
+    title: Notify testers?
+    value_options:
+    - "true"
+    - "false"
+- opts:
+    is_expand: true
+    is_required: false
+    title: Uploaded build related release notes
+  release_notes: $RELEASE_NOTES
+outputs:
+- APPCENTER_DOWNLOAD_URL: $APPCENTER_DOWNLOAD_URL
+  opts:
+    title: Download URL from AppCenter

--- a/steps/appcenter-app-release/1.0.5/step.yml
+++ b/steps/appcenter-app-release/1.0.5/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/fileformat/bitrise-step-appcenter-app-release
 source_code_url: https://github.com/fileformat/bitrise-step-appcenter-app-release
 support_url: https://github.com/fileformat/bitrise-step-appcenter-app-release/issues
-published_at: 2019-11-14T14:29:07.683519-05:00
+published_at: 2019-11-22T11:09:49.651925-05:00
 source:
   git: https://github.com/fileformat/bitrise-step-appcenter-app-release.git
-  commit: 53de7d586a5118ba8931c7d72f87fdfd059ec627
+  commit: caa8294515c2902721a1d72b831446d2ea89bd1c
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -64,6 +64,9 @@ inputs:
     is_expand: true
     is_required: false
     title: AppCenter Mandatory Update flag
+    value_options:
+    - "true"
+    - "false"
 - notify_testers: $NOTIFY_TESTERS
   opts:
     is_expand: true


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2275)

This is the functionality of v1.0.4 that addresses one of the comments with the PR for the 1.0.4 release.  

The step update workflow seems sub-optimal: I can't make a change to the 1.0.4 since it is already tagged in the source repo, so I have to make a new tag (in the source repo) & new PR (in bitrise-steplib).  I also couldn't find the docs for updating a step.  Fortunately, the commands were still in my bash history.

This step will be going away since bitrise is [coming out with their own version](https://github.com/fileformat/bitrise-step-appcenter-app-release/issues/21), so don't think it is worth breaking backwards compatibility on this step, so I have not addressed the pipe vs comma comment.

I also did not address the use of env vars: the script does not use them directly, only in the step.yml, and the snippet is taken directly from the [bitrise docs](https://devcenter.bitrise.io/contributors/create-your-own-step/#secret-environment-variables-in-steps).

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
