### PR TITLE
Create Apple's Documentation v1.0.0

### DIFF
--- a/steps/create-apple-s-documentation/1.0.0/step.yml
+++ b/steps/create-apple-s-documentation/1.0.0/step.yml
@@ -1,0 +1,132 @@
+title: Create Apple's documentation
+summary: |
+  This step helps to create a HTML representation of the Framework documentation, using Jazzy as engine
+description: |
+  This step helps to create a HTML representation of the Framework documentation, using Jazzy as engine.
+  Objective-C and Swift are e supported, but there is no declared supported for mixed language projects.
+  THis was created with the goal to export as a reach HTML documents for Frameworks.
+website: https://github.com/FutureWorkshops/bitrise-step-create-apple-s-documentation
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-create-apple-s-documentation
+support_url: https://github.com/FutureWorkshops/bitrise-step-create-apple-s-documentation/issues
+published_at: 2019-11-22T20:02:44.869801+01:00
+source:
+  git: https://github.com/FutureWorkshops/bitrise-step-create-apple-s-documentation.git
+  commit: 073e907bb4d64cf5178adb39e75cea5c5db42f49
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- macos
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  check_only:
+  - name: xcode
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    is_expand: true
+    is_required: true
+    summary: Path in where the script will be run
+    title: Project path
+  project_path: .
+- language: swift
+  opts:
+    description: |
+      Language used in the project. Either 'swift', or 'objc'.
+
+      At the moment, the step do not support the generation, of documentation
+      for project with mixed language, even if it is a supported feature on Jazzy.
+    is_expand: true
+    is_required: true
+    summary: Language used in the project.
+    title: Language
+    value_options:
+    - objc
+    - swift
+- author: null
+  opts:
+    description: ""
+    is_expand: true
+    is_required: true
+    summary: Author of the Framework
+    title: Author
+- opts:
+    is_expand: true
+    is_required: true
+    summary: SDK to which the code is directed
+    title: SDK
+    value_options:
+    - iphone
+    - mac
+    - tv
+    - none
+  sdk: iphone
+- opts:
+    description: ""
+    is_expand: true
+    is_required: true
+    summary: Version string that will be used as Module Version in the documentation
+    title: Module Version
+  version: 1.0.0
+- framework_root: .
+  opts:
+    is_expand: true
+    is_required: true
+    summary: Root path of where the Framework is
+    title: Root path of the Framework
+- module: null
+  opts:
+    is_expand: true
+    is_required: true
+    summary: Name of the module (also used as scheme)
+    title: Module name
+- acl: public
+  opts:
+    is_expand: true
+    is_required: true
+    title: The minimun ACL used to list the included classes on the doc set
+    value_options:
+    - open
+    - public
+    - internal
+    - private
+- opts:
+    is_expand: true
+    is_required: true
+    summary: Path to where the generated files will be saved
+    title: Output of the doc set
+  output: ./docs
+- opts:
+    description: |
+      This is used to compose the final documentation with a reach index page. The Markdown file is placed as the initial page
+      and all classes are accessible through the class index. By default, the tool uses any README.md file placed in the root of the command,
+      but this can be overwritten with this input.
+    is_expand: true
+    is_required: true
+    summary: Path to the Markdown file that will be used as index of the documentation.
+    title: README file path
+  readme: ./README.md
+- opts:
+    is_expand: true
+    is_required: false
+    summary: Message used as header title in the doc set
+    title: Title of the project
+  title: null
+- copyright: null
+  opts:
+    is_expand: true
+    is_required: false
+    title: Copyright message
+- opts:
+    is_expand: true
+    is_required: false
+    summary: This is used by Objective-C documentation generation. Optional for Swift
+    title: Path to the Framework umbrella header
+  umbrella_header: null


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2277)

### Step description

This is a step that allows the Bitrise CI to run a [Jazzy](https://github.com/realm/jazzy) command to create and export formatted Apple documentation. This is useful for Framework developers that want to create a doc file to publish.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
