### PR TITLE
bitbucket-server-post-build-status 0.0.2

### DIFF
--- a/steps/bitbucket-server-post-build-status/0.0.2/step.yml
+++ b/steps/bitbucket-server-post-build-status/0.0.2/step.yml
@@ -1,0 +1,64 @@
+title: Bitbucket server post build status
+summary: |
+  Post build status to bitbucket server
+description: |
+  Post build status to bitbucket server
+website: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status
+source_code_url: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status
+support_url: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status/issues
+published_at: 2019-12-11T09:47:25.736894+01:00
+source:
+  git: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status.git
+  commit: 15a5aa33911ef2c7be79001803118cfe2252dbf0
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: false
+inputs:
+- bitbucket_server_domain: null
+  opts:
+    is_required: true
+    summary: Full domain name without protocol eg 'my-domain.com'
+    title: Bitbucket Server domain name
+- bitbucket_server_username: null
+  opts:
+    is_required: true
+    summary: Username used to make REST calls
+    title: Bitbucket Server username
+- bitbucket_server_password: null
+  opts:
+    is_required: true
+    is_sensitive: true
+    summary: Password for username
+    title: Bitbucket Server password
+- build_status: $BITRISE_BUILD_STATUS
+  opts:
+    is_required: true
+    title: Bitrise build status
+- git_clone_commit_hash: $GIT_CLONE_COMMIT_HASH
+  opts:
+    is_required: true
+    title: Git commit hash
+- app_title: $BITRISE_APP_TITLE
+  opts:
+    is_required: true
+    title: Bitrise apptitle
+- build_number: $BITRISE_BUILD_NUMBER
+  opts:
+    is_required: true
+    title: Bitrise build number
+- build_url: $BITRISE_BUILD_URL
+  opts:
+    is_required: true
+    title: Bitrise build url
+- opts:
+    is_required: true
+    title: Bitrise triggered workflow id
+  triggered_workflow_id: $BITRISE_TRIGGERED_WORKFLOW_ID


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2319)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

In favor of https://github.com/bitrise-io/bitrise-steplib/pull/2310

@koral-- I've fixed the env variables. But I do have another question. 

Here's is the script for my step: 

https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status/blob/master/step.sh#L4-L8

According to [the docs](https://devcenter.bitrise.io/builds/available-environment-variables/) a `BITRISE_BUILD_STATUS` with value `1` indicates success. But when running this step I get a `1` for failing builds. Any tips? 

```
$BITRISE_BUILD_STATUS

The current status of the build. The available options are:
  Not finished (0)
  Successful (1)
  Failed (2)
  Aborted with failure (3)
  Aborted with success (4).
```