### PR TITLE
bitrise-step-upload-assets-to-github-release 1.0.0

### DIFF
--- a/steps/bitrise-step-upload-assets-to-github-release/1.0.0/step.yml
+++ b/steps/bitrise-step-upload-assets-to-github-release/1.0.0/step.yml
@@ -23,6 +23,9 @@ deps:
   brew:
   - name: git
   - name: hub
+  apt:
+  - name: git
+  - name: hub
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
@@ -37,7 +40,9 @@ inputs:
     summary: |
       Enables "hub" debug output
     title: Debug this step
-    value_options: []
+    value_options:
+    - "true"
+    - "false"
 - github_pat: null
   opts:
     description: |

--- a/steps/bitrise-step-upload-assets-to-github-release/1.0.0/step.yml
+++ b/steps/bitrise-step-upload-assets-to-github-release/1.0.0/step.yml
@@ -1,0 +1,73 @@
+title: Upload assets to Github Release
+summary: |
+  Upload assets to Github Release
+description: |
+  Attach asset(s) from your build to an existing Github Release. When building a tag, the Release will be looked via that tag.
+  By default, it will try and cache all Android and iOS artifacts.
+website: https://github.com/jasperroel/bitrise-step-upload-assets-to-github-release
+source_code_url: https://github.com/jasperroel/bitrise-step-upload-assets-to-github-release
+support_url: https://github.com/jasperroel/bitrise-step-upload-assets-to-github-release/issues
+published_at: 2019-12-18T13:30:02.391022+01:00
+source:
+  git: https://github.com/jasperroel/bitrise-step-upload-assets-to-github-release.git
+  commit: 9185ef8bdf36efc230546addf50d991bb180c9dc
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: hub
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- debug: false
+  opts:
+    description: |
+      Enables "hub" debug output
+    is_expand: true
+    is_required: false
+    summary: |
+      Enables "hub" debug output
+    title: Debug this step
+    value_options: []
+- github_pat: null
+  opts:
+    description: |
+      Uploads any asset to a existing Github Release
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: |
+      A Github Personal Access Token that can write to a Release.
+      Should have at least `repo` permission to the repository (/organisation).
+    title: Github Personal Access Token
+    value_options: []
+- github_release_tag: $BITRISE_GIT_TAG
+  opts:
+    description: |
+      The Github Release to attach the files to. Should be the URL slug name (for example: `v3.15.0-21419`).
+      Defaults to the tag currently building.
+    is_expand: true
+    is_required: true
+    summary: |
+      The Github Release to attach the files to. Should be the URL slug name (for example: `v3.15.0-21419`).
+    title: Github Release name
+    value_options: []
+- files_to_attach_list: $BITRISE_APK_PATH_LIST|$BITRISE_IPA_PATH
+  opts:
+    description: |
+      The file(s) to attach to the Release. Can be a |-seperated list. Each item will be bash-expanded and uploaded individually.
+    is_expand: true
+    is_required: true
+    summary: |
+      The file(s) to attach to the Release
+    title: File(s) to attach.
+    value_options: []


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2335)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

Note: there is no icon for this plugin.
# Testing
For testing, you need:
-  a valid "Github Personal Action Token" with `repo` permissions
- a valid "README.md" with content in your _tmp folder
- a valid repository/release to attach this file to