### PR TITLE
bitrise-step-xctest-cobertura-xml 1.0.0

### DIFF
--- a/steps/bitrise-step-xctest-cobertura-xml/1.0.0/step.yml
+++ b/steps/bitrise-step-xctest-cobertura-xml/1.0.0/step.yml
@@ -1,4 +1,4 @@
-title: XCTest result to Cobertura XML
+title: Convert XCTest result to Cobertura XML
 summary: |
   Converts XCTest results to cobertura compatible xml
 description: |
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
 source_code_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
 support_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml/issues
-published_at: 2020-01-08T15:09:34.830324+02:00
+published_at: 2020-01-13T09:46:15.420146+02:00
 source:
   git: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml.git
-  commit: a7c4241cd36da299b4093948bf6097f9c0e65fa2
+  commit: c7a5ab2fb18259aebcf86ff5c8f8ac288a4a0dbe
 host_os_tags:
 - osx-10.10
 project_type_tags:
@@ -19,14 +19,14 @@ project_type_tags:
 - react-native
 - cordova
 - ionic
+- flutter
 type_tags:
 - utility
-- test
 toolkit:
   go:
     package_name: github.com/ollitapa/bitrise-step-xctest-cobertura-xml
 is_requires_admin_user: false
-is_always_run: false
+is_always_run: true
 is_skippable: false
 run_if: ""
 inputs:
@@ -43,7 +43,7 @@ inputs:
 - opts:
     description: |
       Directory where to put the resulting `coverage.json` and `cobertura.xml`
-      Defualt is `$BITRISE_DEPLOY_DIR`
+      Default is `$BITRISE_DEPLOY_DIR`
     is_expand: true
     is_required: true
     summary: Directory where to put the resulting cobertura.xml

--- a/steps/bitrise-step-xctest-cobertura-xml/1.0.0/step.yml
+++ b/steps/bitrise-step-xctest-cobertura-xml/1.0.0/step.yml
@@ -1,0 +1,64 @@
+title: XCTest result to Cobertura XML
+summary: |
+  Converts XCTest results to cobertura compatible xml
+description: |
+  Converts test results from XCTest step to Cobertura formatted xml to be uploaded to Coveralls or Sonarqube
+website: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+source_code_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+support_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml/issues
+published_at: 2020-01-08T15:09:34.830324+02:00
+source:
+  git: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml.git
+  commit: a7c4241cd36da299b4093948bf6097f9c0e65fa2
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- macos
+- xamarin
+- react-native
+- cordova
+- ionic
+type_tags:
+- utility
+- test
+toolkit:
+  go:
+    package_name: github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      Path to XCTest result bundle, usually located in  `..../DerivedData/<Project dir>/Logs/Test`
+      Bitrise Xcode test step provides this in variable `$BITRISE_XCRESULT_PATH`
+    is_expand: true
+    is_required: true
+    summary: Path to XCTest result bundle
+    title: Path to XCTest result bundle
+    value_options: []
+  path_to_xcresult: $BITRISE_XCRESULT_PATH
+- opts:
+    description: |
+      Directory where to put the resulting `coverage.json` and `cobertura.xml`
+      Defualt is `$BITRISE_DEPLOY_DIR`
+    is_expand: true
+    is_required: true
+    summary: Directory where to put the resulting cobertura.xml
+    title: Directory where to put the resulting cobertura.xml
+    value_options: []
+  xml_output_dir: $BITRISE_DEPLOY_DIR
+outputs:
+- COVERAGE_XML_TEST_RESULT_PATH: null
+  opts:
+    description: |
+      Path to the resulting `cobertura.xml`
+    summary: Path to the resulting `cobertura.xml`
+    title: Path to the resulting cobertura.xml
+- COVERAGE_JSON_TEST_RESULT_PATH: null
+  opts:
+    description: Path to the resulting `coverage.json`
+    summary: Path to the resulting `coverage.json`
+    title: Path to the resulting coverage.json


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2347)

Hi, here is a new small step to generate Cobertura formatted XML-file from xcresult bundle produced by Xcode 11. The file can be then uploaded for example to SonarQube. 

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
