### PR TITLE
Get pubspec version and build number 1.0.3

### DIFF
--- a/steps/get-pubspec-version-and-build-number/1.0.3/step.yml
+++ b/steps/get-pubspec-version-and-build-number/1.0.3/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number
 source_code_url: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number
 support_url: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number/issues
-published_at: 2020-01-23T19:12:12.081648-05:00
+published_at: 2020-01-23T19:14:51.218913-05:00
 source:
   git: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number.git
   commit: a058e9fc2e15c02b563bac1339ff03c4ca9637a4

--- a/steps/get-pubspec-version-and-build-number/1.0.3/step.yml
+++ b/steps/get-pubspec-version-and-build-number/1.0.3/step.yml
@@ -1,0 +1,45 @@
+title: Get pubspec version and build number
+summary: |
+  Get the `version` from the pubspec and sets the environment variables
+description: |
+  Get the `version` from pubspec and sets `$PUBSPEC_VERSION`, `$PUBSPEC_VERSION_NAME` and `$PUBSPEC_BUILD_NUMBER`
+website: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number
+source_code_url: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number
+support_url: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number/issues
+published_at: 2020-01-23T19:12:12.081648-05:00
+source:
+  git: https://github.com/ianko/bitrise-step-get-pubspec-version-and-build-number.git
+  commit: a058e9fc2e15c02b563bac1339ff03c4ca9637a4
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- flutter
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    is_expand: true
+    is_required: true
+    title: Path to pubspec.yaml
+  pubspec_path: $BITRISE_SOURCE_DIR/pubspec.yaml
+outputs:
+- PUBSPEC_VERSION: null
+  opts:
+    summary: 'Example: `1.2.43+10`'
+    title: Value of the `version` attribute in the pubspec.yml
+- PUBSPEC_VERSION_NAME: null
+  opts:
+    summary: 'Example: `1.2.43`'
+    title: Part before the `+` in the `PUBSPEC_VERSION`
+- PUBSPEC_BUILD_NUMBER: null
+  opts:
+    summary: 'Example: `10`'
+    title: Part after the `+` in the `PUBSPEC_VERSION`


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2371)

### New Pull Request Checklist

Not depending on any package. Using pure and simple `awk` command to get the version on both OS X and Ubuntu. (#2361)

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
