### PR TITLE
diawi-upload 0.0.5

### DIFF
--- a/steps/diawi-upload/0.0.5/step.yml
+++ b/steps/diawi-upload/0.0.5/step.yml
@@ -1,0 +1,66 @@
+title: Diawi Upload
+summary: |
+  Upload an ipa/apk/zip to Diawi
+description: |
+  Upload an ipa/apk/zip to Diawi
+website: https://github.com/deanWombourne/bitrise-step-diawi-upload
+source_code_url: https://github.com/deanWombourne/bitrise-step-diawi-upload
+support_url: https://github.com/deanWombourne/bitrise-step-diawi-upload/issues
+published_at: 2020-02-17T13:53:55.79031Z
+source:
+  git: https://github.com/deanWombourne/bitrise-step-diawi-upload.git
+  commit: c14ff8544ae30e676d74a6574c7d93ea8b3a65a6
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: npm
+  apt_get:
+  - name: npm
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- api_token: $DIAWI_TOKEN
+  opts:
+    description: |
+      The API token for Diawi.
+
+      It's free to sign up and get one, just go here: https://dashboard.diawi.com/signup.
+      You create an api token in the profile tab.
+    is_expand: true
+    is_required: true
+    summary: Diawi API token
+    title: API token
+- filename: $BITRISE_IPA_PATH
+  opts:
+    description: |
+      The path to the file to upload - defaults to an IPA created by a bitrise archive step
+    is_expand: true
+    is_required: true
+    summary: The path to the file to upload
+    title: ipa/akp/zip file path
+- opts:
+    description: Users will have to provide this to download the app from Diawi. No
+      value in here will allow anyone to download the app.
+    is_expand: true
+    is_required: false
+    is_sensitive: true
+    summary: Users will have to provide this to download the app from Diawi. No value
+      in here will allow anyone to download the app.
+    title: Password
+  password: $DIAWI_UPLOAD_PASSWORD
+outputs:
+- DIAWI_UPLOAD_URL: null
+  opts:
+    description: |
+      The URL of the uploaded file
+    summary: The URL of the uploaded file
+    title: The URL of the uploaded file


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2395)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ? ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

* Step is a wrapper around bitrise node library - it can't really be tested without a valid upload key and a test .ipa file. There is a test file in the step's repo, but the upload key requires a Diawi account. It's an open issue for the test to simply check the format of the command run without actually running it.