### PR TITLE
stamp-appicon-with-version-number 1.2.0

### DIFF
--- a/steps/stamp-appicon-with-version-number/1.2.0/step.yml
+++ b/steps/stamp-appicon-with-version-number/1.2.0/step.yml
@@ -1,0 +1,77 @@
+title: Stamp AppIcon with version number
+summary: |
+  This script will use ImageMagick to stamp the version number to all icons.
+description: |
+  Stamps version "version(build number)" to the bottom of the icon.
+website: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+source_code_url: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+support_url: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number/issues
+published_at: 2020-03-16T15:20:04.666139+02:00
+source:
+  git: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number.git
+  commit: 5da6c0d857bd204eb935c217024a75e0624cb08a
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  go:
+    package_name: github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number
+deps:
+  brew:
+  - name: imagemagick
+  - name: ghostscript
+  apt_get:
+  - name: imagemagick
+  - name: ghostscript
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: "true"
+inputs:
+- opts:
+    description: |
+      Relative path to icons for example `Project/General.xcassets/AppIcon.appiconset`
+    is_expand: true
+    is_required: true
+    summary: Relative path to icons
+    title: Path to icons of the project
+    value_options: []
+  stamp_path_to_icons: null
+- opts:
+    description: |
+      Version number or string for example 0.1 or Dev
+    is_expand: true
+    is_required: true
+    summary: Version number or string
+    title: Version number or string
+    value_options: []
+  stamp_version: null
+- opts:
+    description: |
+      Build number to stamp on the icon. Defaults to `BITRISE_BUILD_NUMBER`
+    is_expand: true
+    is_required: true
+    summary: Build number to stamp on the icon
+    title: Build number to stamp on the icon
+    value_options: []
+  stamp_build_number: $BITRISE_BUILD_NUMBER
+- foreground_color: white
+  opts:
+    description: |
+      Foreground color (text color) of the stamp. Defaults to "white"
+    is_expand: true
+    is_required: true
+    summary: Foreground color of the stamp
+    title: Foreground color of the stamp
+    value_options: []
+- background_color: '#0008'
+  opts:
+    description: |
+      Background color of the stamp. Defaults to translucent black
+    is_expand: true
+    is_required: true
+    summary: Background color of the stamp
+    title: Background color of the stamp
+    value_options: []


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2423)

Updated the step dependencies to include Ghostscript. Probably the dependency was introduced in newer version of imagemagic or catalina, not sure. 

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
