### PR TITLE
Feature: Swiftformat Linting Verification Step

### DIFF
--- a/steps/swiftformat/0.1.0/step.yml
+++ b/steps/swiftformat/0.1.0/step.yml
@@ -8,6 +8,7 @@ description: |
 website: https://github.com/dmiluski/bitrise-step-swiftformat
 source_code_url: https://github.com/dmiluski/bitrise-step-swiftformat
 support_url: https://github.com/dmiluski/bitrise-step-swiftformat/issues
+published_at: 2020-04-09T10:32:19-07:00
 host_os_tags:
   - osx-10.10
   - ubuntu-16.04

--- a/steps/swiftformat/0.1.0/step.yml
+++ b/steps/swiftformat/0.1.0/step.yml
@@ -9,44 +9,40 @@ website: https://github.com/dmiluski/bitrise-step-swiftformat
 source_code_url: https://github.com/dmiluski/bitrise-step-swiftformat
 support_url: https://github.com/dmiluski/bitrise-step-swiftformat/issues
 published_at: 2020-04-09T10:32:19-07:00
+source:
+  git: https://github.com/dmiluski/bitrise-step-swiftformat.git
+  commit: f131b2235ed2e2773822f3799141c6526ef5157f
 host_os_tags:
   - osx-10.10
   - ubuntu-16.04
-
 project_type_tags:
   - ios
   - macos
-
 type_tags:
   - utility
-
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: swiftformat
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
 run_if: ""
-
-deps:
-  brew:
-  - name: swiftformat
-
-toolkit:
-  bash:
-    entry_file: step.sh
-
 inputs:
-  - formatting_path:
+  - formatting_path: null
     opts:
       category: Config
-      title: "Select the path where SwiftFormat should lint"
-      summary: ""
       description: ""
       is_required: true
-
+      title: "Select the path where SwiftFormat should lint"
+      summary: ""
   - format_config_file: $BITRISE_SOURCE_DIR/.swiftformat
     opts:
       category: Config
-      title: "Format configuration file"
-      summary: ""
       description: |-
         If you use a custom format configuration for Bitrise, you can specify the path here.
       is_required: false
+      summary: ""
+      title: "Format configuration file"

--- a/steps/swiftformat/0.1.0/step.yml
+++ b/steps/swiftformat/0.1.0/step.yml
@@ -1,0 +1,51 @@
+title: |-
+  SwiftFormat
+summary: |
+  Runs SwiftFormat lint on the project
+description: |
+  Runs SwiftFormat on the project to verify formatted code
+  For more information about SwiftFormat please visit: https://github.com/nicklockwood/SwiftFormat
+website: https://github.com/dmiluski/bitrise-step-swiftformat
+source_code_url: https://github.com/dmiluski/bitrise-step-swiftformat
+support_url: https://github.com/dmiluski/bitrise-step-swiftformat/issues
+host_os_tags:
+  - osx-10.10
+  - ubuntu-16.04
+
+project_type_tags:
+  - ios
+  - macos
+
+type_tags:
+  - utility
+
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+
+deps:
+  brew:
+  - name: swiftformat
+
+toolkit:
+  bash:
+    entry_file: step.sh
+
+inputs:
+  - formatting_path:
+    opts:
+      category: Config
+      title: "Select the path where SwiftFormat should lint"
+      summary: ""
+      description: ""
+      is_required: true
+
+  - format_config_file: $BITRISE_SOURCE_DIR/.swiftformat
+    opts:
+      category: Config
+      title: "Format configuration file"
+      summary: ""
+      description: |-
+        If you use a custom format configuration for Bitrise, you can specify the path here.
+      is_required: false

--- a/steps/swiftformat/step-info.yml
+++ b/steps/swiftformat/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

## References:
[SwiftFormat](https://github.com/nicklockwood/SwiftFormat)
[SwiftForrmat Step Repo](https://github.com/dmiluski/bitrise-step-swiftformat)

## Inspired by Prior Art:
https://github.com/kimdv/bitrise-step-swiftlint

## Goal:
Given SwiftFormat is a solution primarily targeted for code formatting, it lacks the enforcement protection for a repo. Although git hooks can make for autoformatting to occur automatically, it also is not a requirement to perform changes/PRs.

This is an attempt to provide a format enforcement step to ensure the code adhears to a format definition.