### PR TITLE
bitbucket-server-post-build-status 0.0.11

### DIFF
--- a/steps/bitbucket-server-post-build-status/0.0.11/step.yml
+++ b/steps/bitbucket-server-post-build-status/0.0.11/step.yml
@@ -1,0 +1,85 @@
+title: Bitbucket server post build status
+summary: |
+  Post build status to bitbucket server
+description: |
+  Post build status to bitbucket server
+website: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status
+source_code_url: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status
+support_url: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status/issues
+published_at: 2020-04-23T19:48:26.712315+02:00
+source:
+  git: https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status.git
+  commit: 8be387006477f130bc0e54c9cf1f95beb24bf542
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+inputs:
+- domain: null
+  opts:
+    description: Full domain name without protocol eg 'my-domain.com'
+    is_required: true
+    summary: Full domain name without protocol eg 'my-domain.com'
+    title: Bitbucket Server domain name
+- opts:
+    description: The username used to make REST calls to bitbucket server
+    is_required: true
+    summary: The username used to make REST calls to bitbucket server
+    title: Bitbucket Server username
+  username: null
+- opts:
+    description: The password for the bitbucket server username
+    is_required: true
+    is_sensitive: true
+    summary: The password for the bitbucket server username
+    title: Bitbucket Server password
+  password: null
+- opts:
+    description: |-
+      If not set to `AUTO`, this step will set a specific status instead of reporting the current build status.
+
+      Can be one of `AUTO`, `INPROGRESS`, `SUCCESSFUL`, or `FAILED`.
+
+      If you don't set this option, or select `AUTO`, the step will send `SUCCESSFUL` status if the current build status is `SUCCESSFUL`
+      (no step failed previously) and `FAILED` status if the build previously failed.
+
+      Use this to report `INPROGRESS` for builds that are just started.
+    summary: Override bitrise build status
+    title: Set Specific Status
+    value_options:
+    - AUTO
+    - INPROGRESS
+    - SUCCESSFUL
+    - FAILED
+  preset_status: AUTO
+- git_clone_commit_hash: $GIT_CLONE_COMMIT_HASH
+  opts:
+    is_required: true
+    title: Git commit hash
+- app_title: $BITRISE_APP_TITLE
+  opts:
+    is_dont_change_value: true
+    is_required: true
+    title: Bitrise app title
+- build_number: $BITRISE_BUILD_NUMBER
+  opts:
+    is_dont_change_value: true
+    is_required: true
+    title: Bitrise build number
+- build_url: $BITRISE_BUILD_URL
+  opts:
+    is_dont_change_value: true
+    is_required: true
+    title: Bitrise build url
+- opts:
+    is_dont_change_value: true
+    is_required: true
+    title: Bitrise triggered workflow id
+  triggered_workflow_id: $BITRISE_TRIGGERED_WORKFLOW_ID


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2460)

Fixes regression https://github.com/teameh/bitrise-step-bitbucket-server-post-build-status/issues/4

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

