### PR TITLE
version-extractor-android 0.0.2

### DIFF
--- a/steps/version-extractor-android/0.0.2/step.yml
+++ b/steps/version-extractor-android/0.0.2/step.yml
@@ -1,0 +1,60 @@
+title: Get versionName and versionCode on Android
+summary: |
+  Extract the versionName and the versionCode on an Android project using a Gradle task
+description: |
+  Extracts the version name and the version code from the Android project. It is useful if the versionName and versionCode values are defined somewhere else. Therefore, this step uses a Gradle task to print these two values. It supports Groovy and Kotlin DSL files.
+website: https://github.com/vladimirpetrovski/bitrise-step-version-extractor-android
+source_code_url: https://github.com/vladimirpetrovski/bitrise-step-version-extractor-android
+support_url: https://github.com/vladimirpetrovski/bitrise-step-version-extractor-android/issues
+published_at: 2020-05-04T11:45:24.12359+02:00
+source:
+  git: https://github.com/vladimirpetrovski/bitrise-step-version-extractor-android.git
+  commit: 0fa9b1def02f09d776976ed3739e59c79c97da72
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- android
+- react-native
+- cordova
+- ionic
+- flutter
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- build_gradle_path: $BITRISE_SOURCE_DIR/app/build.gradle
+  opts:
+    is_required: true
+    summary: Path to the app's build.gradle file where the versionCode and versionName
+      are defined.
+    title: Path to the build.gradle file
+- gradlew_path: $GRADLEW_PATH
+  opts:
+    category: Config
+    description: |
+      Using a Gradle Wrapper (gradlew) is required, as the wrapper ensures
+      that the right Gradle version is installed and used for the build.
+      You can find more information about the Gradle Wrapper (gradlew),
+      and about how you can generate one
+      in the official guide at: [https://docs.gradle.org/current/userguide/gradle_wrapper.html](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+      **The path should be relative** to the repository root. For example, `./gradlew`,
+      or if it is in a sub directory, `./sub/dir/gradlew`.
+    is_required: true
+    title: gradlew file path
+outputs:
+- EXTRACTED_ANDROID_VERSION_NAME: null
+  opts:
+    summary: The extracted versionName value usually located in the app's `build.gradle`
+      file.
+    title: Extracted versionName value
+- EXTRACTED_ANDROID_VERSION_CODE: null
+  opts:
+    summary: The extracted versionCode value located in the app's `build.gradle` file.
+    title: Extracted versionCode value


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2469)

### New Pull Request Checklist
This pull request includes fixes from https://github.com/bitrise-io/bitrise-steplib/pull/2467

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.