### PR TITLE
Onesignal create push 0.0.1

### DIFF
--- a/steps/onesignal-create-push/0.0.1/step.yml
+++ b/steps/onesignal-create-push/0.0.1/step.yml
@@ -25,13 +25,7 @@ project_type_tags:
 type_tags:
 - notification
 toolkit: {}
-deps:
-  brew:
-  - name: git
-  - name: wget
-  apt_get:
-  - name: git
-  - name: wget
+
 is_requires_admin_user: true
 is_always_run: true
 is_skippable: false

--- a/steps/onesignal-create-push/0.0.1/step.yml
+++ b/steps/onesignal-create-push/0.0.1/step.yml
@@ -1,88 +1,69 @@
-
-#
-# A couple of useful guides & docs:
-#
-# - Main Bitrise CLI docs: https://github.com/bitrise-io/bitrise/tree/master/_docs
-# - Step Development Guideline: https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
-# - Bitrise.yml format spec: https://github.com/bitrise-io/bitrise/blob/master/_docs/bitrise-yml-format-spec.md
-# - Bitrise docs: http://devcenter.bitrise.io/
-# - Bitrise CLI guides: http://devcenter.bitrise.io/bitrise-cli/
-
 title: |
-    OneSignal Create Push
+  OneSignal Create Push
 summary: |
-    Create a notification with onesignal. You can send notification with existing OneSignal app
+  Create a notification with onesignal. You can send notification with existing OneSignal app
 description: |
-    Create a notification with onesignal. You can send notification with existing OneSignal app
+  Create a notification with onesignal. You can send notification with existing OneSignal app
 website: https://github.com/sonifex/bitrise-step-onesignal-create-push
 source_code_url: https://github.com/sonifex/bitrise-step-onesignal-create-push
 support_url: https://github.com/sonifex/bitrise-step-onesignal-create-push/issues
-published_at: 2020-05-09T13:53:15+00:00
+published_at: 2020-05-09T17:07:55.992745+03:00
 source:
   git: https://github.com/sonifex/bitrise-step-onesignal-create-push.git
   commit: 2c05994e6a465eda27cb61527d1c895e9880b4a5
 host_os_tags:
-    - osx-10.10
-    - ubuntu-16.04
-
-
+- osx-10.10
+- ubuntu-16.04
 project_type_tags:
-    - ios
-    - macos
-    - android
-    - xamarin
-    - react-native
-    - cordova
-    - ionic
-
+- ios
+- macos
+- android
+- xamarin
+- react-native
+- cordova
+- ionic
 type_tags:
-    - notification
-
+- notification
+toolkit: {}
+deps:
+  brew:
+  - name: git
+  - name: wget
+  apt_get:
+  - name: git
+  - name: wget
 is_requires_admin_user: true
 is_always_run: true
 is_skippable: false
 run_if: ""
-
-deps:
-    brew:
-        - name: git
-        - name: wget
-    apt_get:
-        - name: git
-        - name: wget
-
-toolkit:
-    bash:
-    entry_file: step.sh
-
 inputs:
-    - onesignal_rest_api_key: ""
-      opts:
-        title: |
-            "OneSignal Rest API KEY"
-        is_expand: true
-        is_required: true
-        is_sensitive: true
-    - onesignal_app_id: ""
-      opts:
-        title: |
-            "OneSignal App ID"
-        is_expand: true
-        is_required: true
-        is_sensitive: true
-    - app_public_install_page: "$BITRISE_PUBLIC_INSTALL_PAGE_URL"
-      opts:
-        title: "App Public Install Page Url"
-        is_expand: true
-    - push_title: ""
-      opts:
-        title: |
-            "Push Notification Title"
-        is_expand: true
-        is_required: true
-    - push_body: ""
-      opts:
-        title: |
-            "Push Notification Message"
-        is_expand: true
-        is_required: true
+- onesignal_rest_api_key: ""
+  opts:
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: |
+      "OneSignal Rest API KEY"
+- onesignal_app_id: ""
+  opts:
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: |
+      "OneSignal App ID"
+- app_public_install_page: $BITRISE_PUBLIC_INSTALL_PAGE_URL
+  opts:
+    is_expand: true
+    title: App Public Install Page Url
+- opts:
+    is_expand: true
+    is_required: true
+    title: |
+      "Push Notification Title"
+  push_title: ""
+- opts:
+    is_expand: true
+    is_required: true
+    title: |
+      "Push Notification Message"
+  push_body: ""

--- a/steps/onesignal-create-push/0.0.1/step.yml
+++ b/steps/onesignal-create-push/0.0.1/step.yml
@@ -20,7 +20,7 @@ support_url: https://github.com/sonifex/bitrise-step-onesignal-create-push/issue
 published_at: 2020-05-09T13:53:15+00:00
 source:
   git: https://github.com/sonifex/bitrise-step-onesignal-create-push.git
-  branch: master
+  commit: 2c05994e6a465eda27cb61527d1c895e9880b4a5
 host_os_tags:
     - osx-10.10
     - ubuntu-16.04


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2491)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.
For steps added for the first time, the GitHub option **Allow edits from maintainers** is required (See the documentation on how to select it: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.