### PR TITLE
get-flutter-version 0.0.1

### DIFF
--- a/steps/get-flutter-version/0.0.1/step.yml
+++ b/steps/get-flutter-version/0.0.1/step.yml
@@ -1,0 +1,56 @@
+title: Get Flutter version
+summary: |
+  Extract the Flutter version that is defined in pubspec
+description: |
+  Extracts the Flutter version from pubspec.lock (if present) or pubspec.yaml and sets `$FLUTTER_PUBSPEC_VERSION` environmental variable.
+website: https://github.com/dgimb89/bitrise-step-get-flutter-version
+source_code_url: https://github.com/dgimb89/bitrise-step-get-flutter-version
+support_url: https://github.com/dgimb89/bitrise-step-get-flutter-version/issues
+published_at: 2020-05-17T22:24:38.682957+02:00
+source:
+  git: https://github.com/dgimb89/bitrise-step-get-flutter-version.git
+  commit: e0f02f459ea0987e21f8a6df52b99e12b02037ff
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- flutter
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: perl
+  apt_get:
+  - name: perl
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: The root dir of your Flutter project that contains pubspec.yaml and
+      optionally pubspec.lock.
+    is_required: true
+    summary: The root dir of your Flutter project.
+    title: Project Location
+  project_location: $BITRISE_SOURCE_DIR
+outputs:
+- FLUTTER_PUBSPEC_VERSION: null
+  opts:
+    description: 'Minimum Flutter version requirement that is defined by pubspec at
+      the *project location*: The version defined in pubspec.lock takes precendence
+      over pubspec.yaml definition.'
+    title: Flutter version that is defined by pubspec
+- FLUTTER_PUBSPEC_YAML_VERSION: null
+  opts:
+    description: Minimum Flutter version requirement that is defined in pubspec.yaml
+      file at the *project location*.
+    title: Flutter version that is defined by pubspec
+- FLUTTER_PUBSPEC_LOCK_VERSION: null
+  opts:
+    description: Minimum Flutter version requirement that is defined in pubspec.lock
+      file at the *project location*.
+    title: Flutter version that is defined by pubspec

--- a/steps/get-flutter-version/0.0.1/step.yml
+++ b/steps/get-flutter-version/0.0.1/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/dgimb89/bitrise-step-get-flutter-version
 source_code_url: https://github.com/dgimb89/bitrise-step-get-flutter-version
 support_url: https://github.com/dgimb89/bitrise-step-get-flutter-version/issues
-published_at: 2020-05-17T22:24:38.682957+02:00
+published_at: 2020-05-19T00:54:24.119654+02:00
 source:
   git: https://github.com/dgimb89/bitrise-step-get-flutter-version.git
   commit: e0f02f459ea0987e21f8a6df52b99e12b02037ff

--- a/steps/get-flutter-version/0.0.1/step.yml
+++ b/steps/get-flutter-version/0.0.1/step.yml
@@ -1,15 +1,14 @@
-title: Get Flutter version
-summary: |
-  Extract the Flutter version that is defined in pubspec
-description: |
-  Extracts the Flutter version from pubspec.lock (if present) or pubspec.yaml and sets `$FLUTTER_PUBSPEC_VERSION` environmental variable.
+title: Get Flutter version from pubspec
+summary: Extracts minimum required Flutter version from pubspec files
+description: Extracts the Flutter version from *pubspec.lock* (if present) or *pubspec.yaml*
+  and sets `$FLUTTER_PUBSPEC_VERSION` environment variable.
 website: https://github.com/dgimb89/bitrise-step-get-flutter-version
 source_code_url: https://github.com/dgimb89/bitrise-step-get-flutter-version
 support_url: https://github.com/dgimb89/bitrise-step-get-flutter-version/issues
-published_at: 2020-05-19T00:54:24.119654+02:00
+published_at: 2020-05-19T01:27:05.863186+02:00
 source:
   git: https://github.com/dgimb89/bitrise-step-get-flutter-version.git
-  commit: e0f02f459ea0987e21f8a6df52b99e12b02037ff
+  commit: 158bb9d40d1da2224abcac07429c74698d8e5b61
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -31,26 +30,26 @@ is_skippable: false
 run_if: ""
 inputs:
 - opts:
-    description: The root dir of your Flutter project that contains pubspec.yaml and
-      optionally pubspec.lock.
+    description: The root dir of your Flutter project that contains *pubspec.yaml*
+      and optionally *pubspec.lock*.
     is_required: true
-    summary: The root dir of your Flutter project.
+    summary: The root dir of your Flutter project
     title: Project Location
   project_location: $BITRISE_SOURCE_DIR
 outputs:
 - FLUTTER_PUBSPEC_VERSION: null
   opts:
     description: 'Minimum Flutter version requirement that is defined by pubspec at
-      the *project location*: The version defined in pubspec.lock takes precendence
-      over pubspec.yaml definition.'
+      the **project location**: The version defined in *pubspec.lock* takes precendence
+      over *pubspec.yaml* definition.'
     title: Flutter version that is defined by pubspec
 - FLUTTER_PUBSPEC_YAML_VERSION: null
   opts:
-    description: Minimum Flutter version requirement that is defined in pubspec.yaml
-      file at the *project location*.
+    description: Minimum Flutter version requirement that is defined in *pubspec.yaml*
+      file at the **project location**.
     title: Flutter version that is defined by pubspec
 - FLUTTER_PUBSPEC_LOCK_VERSION: null
   opts:
-    description: Minimum Flutter version requirement that is defined in pubspec.lock
-      file at the *project location*.
+    description: Minimum Flutter version requirement that is defined in *pubspec.lock*
+      file at the **project location**.
     title: Flutter version that is defined by pubspec


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2494)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.