### PR TITLE
bitrise-step-xctest-cobertura-xml 1.2.0

### DIFF
--- a/steps/bitrise-step-xctest-cobertura-xml/1.2.0/step.yml
+++ b/steps/bitrise-step-xctest-cobertura-xml/1.2.0/step.yml
@@ -1,0 +1,75 @@
+title: Convert XCTest result to Cobertura XML
+summary: |
+  Converts XCTest results to cobertura compatible xml
+description: |
+  Converts test results from XCTest step to Cobertura formatted xml to be uploaded to Coveralls or Sonarqube
+website: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+source_code_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+support_url: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml/issues
+published_at: 2020-05-18T11:45:52.567908+03:00
+source:
+  git: https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml.git
+  commit: e9d93fba557f15023d7077f10e438148a47dbc8e
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- macos
+- xamarin
+- react-native
+- cordova
+- ionic
+- flutter
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/ollitapa/bitrise-step-xctest-cobertura-xml
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      Path to XCTest result bundle, usually located in  `..../DerivedData/<Project dir>/Logs/Test`
+      Bitrise Xcode test step provides this in variable `$BITRISE_XCRESULT_PATH`
+    is_expand: true
+    is_required: true
+    summary: Path to XCTest result bundle
+    title: Path to XCTest result bundle
+    value_options: []
+  path_to_xcresult: $BITRISE_XCRESULT_PATH
+- opts:
+    description: |
+      Directory where to put the resulting `coverage.json` and `cobertura.xml`
+      Default is `$BITRISE_DEPLOY_DIR`
+    is_expand: true
+    is_required: true
+    summary: Directory where to put the resulting cobertura.xml
+    title: Directory where to put the resulting cobertura.xml
+    value_options: []
+  xml_output_dir: $BITRISE_DEPLOY_DIR
+- opts:
+    description: |
+      Directory where the source files that used by xcode to create the test "Path to the resulting coverage.json"
+      This directory is referenced by the <sources> item of cobertura xml.
+      Default is `$BITRISE_SOURCE_DIR`
+    is_expand: true
+    is_required: true
+    summary: Directory where the source files are located.
+    title: Directory where the source files are located.
+    value_options: []
+  path_to_source_dir: $BITRISE_SOURCE_DIR
+outputs:
+- COVERAGE_XML_TEST_RESULT_PATH: null
+  opts:
+    description: |
+      Path to the resulting `cobertura.xml`
+    summary: Path to the resulting `cobertura.xml`
+    title: Path to the resulting cobertura.xml
+- COVERAGE_JSON_TEST_RESULT_PATH: null
+  opts:
+    description: Path to the resulting `coverage.json`
+    summary: Path to the resulting `coverage.json`
+    title: Path to the resulting coverage.json


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2495)

Fixed a small compatibility issue with older version of Go. Also added CI-test to step-repo.
https://github.com/ollitapa/bitrise-step-xctest-cobertura-xml/issues/2

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
