### PR TITLE
Added maintainer for future get-flutter-version step

### DIFF
--- a/steps/get-flutter-version/step-info.yml
+++ b/steps/get-flutter-version/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
This PR adds the missing step-info.yml so that the pipeline for #2494 can pass.