### PR TITLE
git-tag-project-version-and-build-number 1.0.8

### DIFF
--- a/steps/git-tag-project-version-and-build-number/1.0.8/step.yml
+++ b/steps/git-tag-project-version-and-build-number/1.0.8/step.yml
@@ -1,0 +1,71 @@
+title: Git tag project version and build number
+summary: |
+  Git tag project version and build number
+description: |
+  This step will create Git tag with project version and build number
+website: https://github.com/ned1988/bitrise-step-git-tag-project-version-and-build-number
+source_code_url: https://github.com/ned1988/bitrise-step-git-tag-project-version-and-build-number
+support_url: https://github.com/ned1988/bitrise-step-git-tag-project-version-and-build-number
+published_at: 2020-05-21T23:42:01.150583+02:00
+source:
+  git: https://github.com/denys-meloshyn/bitrise-step-git-tag-project-version-and-build-number.git
+  commit: 088919a05e3dafad7cd3433c8d1294ec0d443f8f
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- ios
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  apt_get:
+  - name: git
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- bitrise_tag_xcodeproj_path: ""
+  opts:
+    description: |
+      Use it with Xcode 11 and higher.
+    is_required: false
+    summary: Path to the 'xcodeproj'
+    title: Path to the 'xcodeproj'
+- bitrise_tag_info_plist_path: ""
+  opts:
+    description: |
+      File of your release 'Info.plist' file.
+    is_required: true
+    summary: Path to the 'Info.plist' file
+    title: Path to the 'Info.plist'
+- bitrise_tag_format: v_VERSION_(_BUILD_)
+  opts:
+    description: |
+      Provide format of generated tag & build number. You can use the following placeholders: ``_VERSION_``, ``_BUILD_``
+    is_required: false
+    summary: Provide format of generated tag & build number
+    title: Result format
+- opts:
+    category: Config
+    description: |
+      If yes, the tag will be lightweight, i.e. not trigger a commit/push
+    title: Use lightweight tag?
+    value_options:
+    - "no"
+    - "yes"
+  use_lightweight_tag: "no"
+outputs:
+- EXAMPLE_STEP_OUTPUT: null
+  opts:
+    description: |
+      Description of this output.
+
+      Can be Markdown formatted text.
+    summary: Summary. No more than 2-3 sentences.
+    title: Example Step Output


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2510)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
