### PR TITLE
[URGENT] xcuitestbrowserstack 1.0.12. [API Update from borwsersack - and have to support two different responses ]

### DIFF
--- a/steps/xcuitestbrowserstack/1.0.12/step.yml
+++ b/steps/xcuitestbrowserstack/1.0.12/step.yml
@@ -1,0 +1,87 @@
+title: Browserstack iOS UI Test
+summary: |
+  Execute XCUITests on Browserstack Platform with retry logic
+description: |
+  This step will help you to execute iOS UI Automation tests on Browserstack platform. Automatically manages device queue and retries failed tests and also reports test status.
+website: https://github.com/satheeshkumarf/bitrise-step-executexcuitestonbrowserstack
+source_code_url: https://github.com/satheeshkumarf/bitrise-step-executexcuitestonbrowserstack
+support_url: https://github.com/satheeshkumarf/bitrise-step-executexcuitestonbrowserstack/issues
+published_at: 2020-06-03T23:04:39.748349+04:00
+source:
+  git: https://github.com/satheeshkumarf/bitrise-step-executexcuitestonbrowserstack.git
+  commit: f88e7ee12d46ac14ee1638cd438dae34aeef7645
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- macos
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: browserstack.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- browserstack_app_url: null
+  opts:
+    is_expand: true
+    is_required: true
+    summary: IPA url of the app uploaded to Browserstack Server. You can use browserstack-upload
+      bitrise step to upload your ipa.
+    title: Browserstack ipa url
+- opts:
+    description: |
+      Sample file format:
+          SearchListingsTest/testXYZ=iPhone 6-11.2
+          SearchFilterTest/testABC=iPhone XS-12.1
+    is_expand: true
+    is_required: true
+    summary: Specifiy path to the file which contains your test and device details.
+      Use .txt file to specify your test name and device details separated by equal
+      to sign.
+    title: Test file path
+  tests_file_path: null
+- browserstack_xcuitest_url: null
+  opts:
+    is_expand: true
+    is_required: true
+    summary: Build your XCUITests and publish it to Browserstack server. Specify the
+      test_url path returned from browserstack in this variable.
+    title: Browserstack xcuitest url
+- browserstack_username: null
+  opts:
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: Browserstack username
+- browserstack_password: null
+  opts:
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: Browserstack access key
+- browserstack_local: "false"
+  opts:
+    is_expand: true
+    is_required: true
+    summary: Set this value to true for enabling testing on your private test environment.
+    title: Enable local testing feature of Browserstack
+    value_options:
+    - "true"
+    - "false"
+- browserstack_local_id: null
+  opts:
+    is_expand: true
+    is_required: false
+    title: Specify unique local connection name
+- opts:
+    is_expand: true
+    is_required: true
+    summary: By default retry count is set as zero, which will not re-execute failed
+      tests. If you specify a value greater than zero, only the failed tests will
+      be re-executed to see if the issue was a random flakiness.
+    title: Retry count for failed tests
+  retry_count: "0"


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2536)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [yes] __I will not move an already shared step version's tag to another commit__
- [yes] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [yes] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [yes] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [yes] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
