### PR TITLE
step-jira-number-from-branch 1.0.0

### DIFF
--- a/steps/step-jira-number-from-branch/1.0.0/step.yml
+++ b/steps/step-jira-number-from-branch/1.0.0/step.yml
@@ -1,0 +1,66 @@
+title: jira-number-from-branch
+summary: |
+  Extract JIRA issue number from Git branch
+description: |
+  Get JIRA issue number from current Git branch
+website: https://github.com/denys-meloshyn/bitrise-step-jira-number-from-branch
+source_code_url: https://github.com/denys-meloshyn/bitrise-step-jira-number-from-branch
+support_url: https://github.com/denys-meloshyn/bitrise-step-jira-number-from-branch/issues
+published_at: 2020-06-11T21:37:26.164607+02:00
+source:
+  git: https://github.com/denys-meloshyn/bitrise-step-jira-number-from-branch.git
+  commit: 7fc8fef4cc0c613151b12406c12a72d66e6e3837
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: wget
+  - name: python
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- bitrise_jira_branch_name: $BITRISE_GIT_BRANCH
+  opts:
+    description: |
+      Branch name from which extract JIRA issue number. For example: $BITRISE_GIT_BRANCH, $BITRISEIO_GIT_BRANCH_DEST
+    is_required: true
+    summary: Branch name from which extract JIRA issue number
+    title: Branch name
+- bitrise_jira_number_prefix: ""
+  opts:
+    description: |
+      JIRA issue has next format PROJECT-XXX where ``PROJECT`` is prefix and ``XXX`` is issue number
+    is_required: true
+    summary: JIRA project prefix
+    title: JIRA prefix
+- bitrise_jira_number_should_fail: "false"
+  opts:
+    description: |
+      In case value option selected as ``true`` step will return error, otherwise ``JIRA_ISSUE_NUMBER_FROM_BRANCH``
+      ``JIRA_ISSUE_NUMBER_FROM_BRANCH`` will contain empty string.
+    is_expand: true
+    is_required: true
+    summary: Should step fail in case of missed JIRA number
+    title: Should fail?
+    value_options:
+    - "true"
+    - "false"
+outputs:
+- JIRA_ISSUE_NUMBER_FROM_BRANCH: null
+  opts:
+    description: |
+      This value will contain extracted JIRA issue number from branch
+    summary: Extracted JIRA issue number
+    title: JIRA issue number


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2546)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.