### PR TITLE
find-jira-issue 0.0.1

### DIFF
--- a/steps/find-jira-issue/0.0.1/step.yml
+++ b/steps/find-jira-issue/0.0.1/step.yml
@@ -1,0 +1,43 @@
+title: Find Jira Issue
+summary: |
+  Find the jira issue and add it as an environment variable
+description: |
+  Step that locates the a jira issue from the input and sets it as an environment variable for future steps
+website: https://github.com/jimmithy/bitrise-step-find-jira-issue
+source_code_url: https://github.com/jimmithy/bitrise-step-find-jira-issue
+support_url: https://github.com/jimmithy/bitrise-step-find-jira-issue/issues
+published_at: 2020-06-26T09:10:58.5386-04:00
+source:
+  git: https://github.com/jimmithy/bitrise-step-find-jira-issue.git
+  commit: 86ee7cdff9975d65bdee4b78ed2500773f1ee2f7
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- FIND_ISSUE_INPUT: $BITRISE_GIT_MESSAGE
+  opts:
+    description: |
+      The input used to locate the jira commit message.
+
+      For example, the git commit message or branch name.
+    is_expand: true
+    is_required: true
+    summary: Where should we look for jira issues
+    title: Input
+    value_options: []
+outputs:
+- JIRA_ISSUE: null
+  opts:
+    description: |
+      Unique Jira issues found from the input. Multiple results will have a | delimiter.
+    summary: The jira issues found in the input
+    title: Jira Issue(s)

--- a/steps/find-jira-issue/0.0.1/step.yml
+++ b/steps/find-jira-issue/0.0.1/step.yml
@@ -9,7 +9,7 @@ support_url: https://github.com/jimmithy/bitrise-step-find-jira-issue/issues
 published_at: 2020-06-26T09:10:58.5386-04:00
 source:
   git: https://github.com/jimmithy/bitrise-step-find-jira-issue.git
-  commit: 86ee7cdff9975d65bdee4b78ed2500773f1ee2f7
+  commit: 4b1566842f7147cbdad6fd65f1d145f56c08c9ed
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -23,19 +23,19 @@ is_always_run: false
 is_skippable: false
 run_if: ""
 inputs:
-- FIND_ISSUE_INPUT: $BITRISE_GIT_MESSAGE
+- find_issue_content: $BITRISE_GIT_MESSAGE
   opts:
     description: |
-      The input used to locate the jira commit message.
+      The input text content used to locate the jira commit message.
 
       For example, the git commit message or branch name.
     is_expand: true
     is_required: true
     summary: Where should we look for jira issues
-    title: Input
+    title: Text Content
     value_options: []
 outputs:
-- JIRA_ISSUE: null
+- JIRA_ISSUE_LIST: null
   opts:
     description: |
       Unique Jira issues found from the input. Multiple results will have a | delimiter.

--- a/steps/find-jira-issue/0.0.1/step.yml
+++ b/steps/find-jira-issue/0.0.1/step.yml
@@ -26,7 +26,7 @@ inputs:
 - find_issue_content: $BITRISE_GIT_MESSAGE
   opts:
     description: |
-      The input text content used to locate the jira commit message.
+      The input text content used to locate the jira ticket number.
 
       For example, the git commit message or branch name.
     is_expand: true

--- a/steps/find-jira-issue/step-info.yml
+++ b/steps/find-jira-issue/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/find-jira-issue/step-info.yml
+++ b/steps/find-jira-issue/step-info.yml
@@ -1,1 +1,0 @@
-maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2570)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.