### PR TITLE
lifx-notifier 1.1.1

### DIFF
--- a/steps/lifx-notifier/1.1.1/step.yml
+++ b/steps/lifx-notifier/1.1.1/step.yml
@@ -1,0 +1,104 @@
+title: LIFX Notifier
+summary: Sends signals to your LIFX bulb during builds.
+description: |-
+  Add this step to your workflow when color change is required.
+
+  This step can be used at the start (notify build start) and at the end (notify success/failure) of your workflow.
+  If there's no need to notify about workflow start than adding step to the end of the workflow will be enough.
+
+  If all colors fields will be empty, default colors will be used:
+  "build start" - yellow, "build success" - green, "build failure" - red.
+website: https://github.com/ShotSkydiver/steps-lifx-notifier
+source_code_url: https://github.com/ShotSkydiver/steps-lifx-notifier
+support_url: https://github.com/ShotSkydiver/steps-lifx-notifier/issues
+published_at: 2020-07-17T14:09:25.627659-06:00
+source:
+  git: https://github.com/ShotSkydiver/steps-lifx-notifier.git
+  commit: 299d9f8466296c6462d02f374d6240fbc9f56fb5
+host_os_tags:
+- osx-10.8
+- osx-10.10
+- ubuntu
+type_tags:
+- utility
+- notification
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+run_if: ""
+inputs:
+- auth_token: null
+  opts:
+    description: |
+      This step uses official LIFX API,
+      which requires OAuth2 Access token (https://api.developer.lifx.com/docs/authentication).
+    is_required: true
+    title: Authentication token
+- opts:
+    description: |
+      By default, only the name of a single light will be triggered. You can change this to specify a group instead.
+    title: Selector type
+    value_options:
+    - label
+    - group
+    - location
+  selector_type: label
+- bulb_label: null
+  opts:
+    description: |
+      This is the name of the LIFX light or group, eg. "Bedroom", "Office".
+    is_required: true
+    title: LIFX light(s) selector label
+- color_build_success: green
+  opts:
+    description: |
+      It can be used after any step in the workflow to notify about current state.
+      e.g.: use "yellow" color to indicate that workflow started
+    title: Build success color (LIFX default)
+    value_options:
+    - blue
+    - cyan
+    - green
+    - orange
+    - pink
+    - purple
+    - red
+    - yellow
+    - white
+- color_build_success_custom: null
+  opts:
+    description: |
+      If custom color provided, it will be used instead of LIFX default.
+      Format RRGGBB, e.g: 00ff00 (green).
+    title: Build success color (custom)
+- color_build_failure: red
+  opts:
+    description: |
+      This color will be used to notify about failure,
+      if no custom color provided.
+    title: Build failure color (LIFX default)
+    value_options:
+    - blue
+    - cyan
+    - green
+    - orange
+    - pink
+    - purple
+    - red
+    - yellow
+    - white
+- color_build_failure_custom: null
+  opts:
+    description: |
+      If custom color provided, it will be used instead of LIFX default.
+      Format RRGGBB, e.g: ff0000 (red).
+    title: Build failure color (custom)
+- effect: none
+  opts:
+    description: |
+      Instead of setting a solid color, do you want to e.g. pulse the light?
+    title: Effect
+    value_options:
+    - none
+    - pulse
+    - breathe


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2596)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
