### PR TITLE
codecov 2.0.1

### DIFF
--- a/steps/codecov/2.0.1/step.yml
+++ b/steps/codecov/2.0.1/step.yml
@@ -1,0 +1,37 @@
+title: Codecov
+summary: Upload your code coverage files to Codecov.io
+description: |-
+  Reduce technical debt with visualized test performance,
+  faster code reviews and workflow enhancements.
+  Now you can upload your code coverage files to Codecov every time you kick off a build!
+website: https://codecov.io
+source_code_url: https://github.com/codecov/codecov-bitrise
+support_url: https://community.codecov.io
+published_at: 2020-11-16T14:11:31.606197-05:00
+source:
+  git: https://github.com/codecov/codecov-bitrise.git
+  commit: 3b298fe8b9de89b884e0a9ab1704eaf431e22700
+host_os_tags:
+- osx-10.10
+- ubuntu-14.04
+type_tags:
+- test
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+inputs:
+- CODECOV_TOKEN: null
+  opts:
+    description: |
+      Codecov.io repository upload token
+    is_required: true
+    is_sensitive: true
+    title: Codecov.io token
+- opts:
+    description: |-
+      Options to pass along to the Codecov uploader.
+      You can use multiple options, separated by a space.
+      Review all options at https://github.com/codecov/codecov-bash
+      For example, `-F unittests -J '^Project'`
+    title: Additional options for Codecov call
+  other_options: -C $BITRISE_GIT_COMMIT


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
