### PR TITLE
update-gitops-repository 0.1.2

### DIFF
--- a/steps/update-gitops-repository/0.1.2/step.yml
+++ b/steps/update-gitops-repository/0.1.2/step.yml
@@ -1,0 +1,89 @@
+title: Update GitOps repository
+summary: |
+  Updates files of a GitOps repository either by pushing changes directly to a
+  given folder of a given branch or by opening a pull request to it.
+description: |
+  Updates files of a GitOps repository either by pushing changes directly to a
+  given folder of a given branch or by opening a pull request to it.
+  URL of the pull request is exposed as an output in the latter case.
+  Updated files are go templates rendered by substituting given values.
+  A Github Personal Access Token must be provided with access to the repository.
+  A temporary SSH key will automatically be added to the repository to push
+  changes. It will also be automatically deleted once the step terminated.
+website: https://github.com/bitrise-io/bitrise-step-update-gitops-repository
+source_code_url: https://github.com/bitrise-io/bitrise-step-update-gitops-repository
+support_url: https://github.com/bitrise-io/bitrise-step-update-gitops-repository/issues
+published_at: 2021-01-13T12:35:20.13584+01:00
+source:
+  git: https://github.com/bitrise-io/bitrise-step-update-gitops-repository.git
+  commit: c98048d90f53baa497e1434252fc843b96987007
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  go:
+    package_name: github.com/bitrise-io/bitrise-step-update-gitops-repository
+deps:
+  brew:
+  - name: git
+  apt_get:
+  - name: git
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- deploy_repository_url: ""
+  opts:
+    is_required: true
+    title: Github SSH URL of the repository to deploy to
+- deploy_path: ""
+  opts:
+    is_required: true
+    title: Path to place rendered templates inside the repository
+- deploy_token: $DEPLOY_TOKEN
+  opts:
+    is_required: true
+    is_sensitive: true
+    title: Personal Access Token to interact with Github API
+- deploy_branch: master
+  opts:
+    title: Branch of the repository to deploy to
+- commit_message: bitrise ci integration
+  opts:
+    title: Commit message of pushed changes
+- opts:
+    category: Templates
+    title: Path to Go templates folder
+  templates_folder_path: deployments/helm
+- opts:
+    category: Templates
+    description: Input values for the Go template files as key-value pairs.
+    title: Input values for the Go template files
+  values: null
+- opts:
+    category: Pull Request
+    description: |
+      Open a pull request instead of pushing
+      changes directly to the given branch.
+    title: Open a pull request
+    value_options:
+    - "true"
+    - "false"
+  pull_request: false
+- opts:
+    category: Pull Request
+    title: Title of the opened pull request
+  pull_request_title: ""
+- opts:
+    category: Pull Request
+    title: Body of the opened pull request
+  pull_request_body: ""
+outputs:
+- PR_URL: null
+  opts:
+    description: |
+      URL of opened pull request. Will be emitted in pull request mode.
+    title: URL of opened pull request

--- a/steps/update-gitops-repository/step-info.yml
+++ b/steps/update-gitops-repository/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2851)

https://github.com/bitrise-io/bitrise-step-update-gitops-repository/releases/0.1.2

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [X] __I will not move an already shared step version's tag to another commit__
- [X] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [X] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [X] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [X] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.