### PR TITLE
beat-android-code-stats 0.0.1

### DIFF
--- a/steps/beat-android-code-stats/0.0.1/step.yml
+++ b/steps/beat-android-code-stats/0.0.1/step.yml
@@ -1,0 +1,63 @@
+title: Android code stats
+summary: |
+  Generates some Android project stats
+description: |
+  Generates some variables for Android project stats
+website: https://github.com/luismunyoz/bitrise-step-beat-android-code-stats
+source_code_url: https://github.com/luismunyoz/bitrise-step-beat-android-code-stats
+support_url: https://github.com/luismunyoz/bitrise-step-beat-android-code-stats/issues
+published_at: 2021-02-12T15:27:02.283766+01:00
+source:
+  git: https://github.com/luismunyoz/bitrise-step-beat-android-code-stats.git
+  commit: 443bc9ed2e5c1abaea24eccf436cf616a88858e1
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- android
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: cloc
+  apt_get:
+  - name: cloc
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+inputs:
+- opts:
+    description: The root directory of your Android project. For example, where your
+      root build gradle file exist (also gradlew, settings.gradle, and so on)
+    is_required: true
+    summary: The root directory of your Android project.
+    title: Project Location
+  project_location: $BITRISE_PROJECT_PATH
+outputs:
+- KOTLIN_LINES_CODE: null
+  opts:
+    summary: Lines of code written in Kotlin
+    title: Kotlin lines of code
+- JAVA_LINES_CODE: null
+  opts:
+    summary: Lines of code written in Java
+    title: Java lines of code
+- XML_LINES_CODE: null
+  opts:
+    summary: Lines of code written in XML
+    title: XML lines of code
+- KOTLIN_PERCENTAGE_CODE: null
+  opts:
+    summary: Percentage of the code written in Kotlin
+    title: Kotlin percentage of code
+- JAVA_PERCENTAGE_CODE: null
+  opts:
+    summary: Percentage of the code written in Java
+    title: Java percentage of code
+- DOCUMENTATION_FILES: null
+  opts:
+    summary: Number of documentation files in the project
+    title: Documentation files


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2910)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.