### PR TITLE
appcenter-codepush-release-react-native 0.0.3

### DIFF
--- a/steps/appcenter-codepush-release-react-native/0.0.3/step.yml
+++ b/steps/appcenter-codepush-release-react-native/0.0.3/step.yml
@@ -1,0 +1,71 @@
+title: AppCenter CodePush Release React Native
+summary: |
+  Release a React Native update to AppCenter CodePush
+description: |
+  Utilise appcenter-cli command appcenter codepush release-react to release an update
+website: https://github.com/adrianchinghc/bitrise-step-appcenter-codepush-release-react-native
+source_code_url: https://github.com/adrianchinghc/bitrise-step-appcenter-codepush-release-react-native
+support_url: https://github.com/adrianchinghc/bitrise-step-appcenter-codepush-release-react-native/issues
+published_at: 2021-03-24T17:24:07.835473+08:00
+source:
+  git: https://github.com/adrianchinghc/bitrise-step-appcenter-codepush-release-react-native.git
+  commit: dc8cee3b16aaf5ae2ca377422cb74f3bff1e7dff
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- react-native
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: node
+  apt_get:
+  - name: node
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      Path where the React Native project is located.
+    is_required: true
+    title: React Native Project Root
+  react_native_project_root: $REACT_NATIVE_PROJECT_ROOT
+- app_id: $APPCENTER_APP_ID
+  opts:
+    description: |
+      AppCenter Application Identifier is a combination of your Organization/Owner Name and an Application Name.
+      For example: `Upstack-Studio/bitrise-android`
+    is_required: true
+    summary: AppCenter application identifier (Organization/Owner Name + App Name).
+    title: AppCenter App ID
+- api_token: $APPCENTER_API_TOKEN
+  opts:
+    description: |
+      AppCenter API Token can be obtained from [here](https://appcenter.ms/settings/apitokens). `New API Token` > `Enter a description for the token` > `Select Full Access` > `Add New API Token`
+    is_required: true
+    is_sensitive: true
+    title: AppCenter API Token
+- deployment: Staging
+  opts:
+    description: |
+      This specifies which deployment you want to release the update to. This defaults to Staging, but when you're ready to deploy to Production, or one of your own custom deployments, just explicitly set this argument. See [here](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/cli#deployment-name-parameter) for details.
+    is_required: true
+    title: Deployment
+- description: null
+  opts:
+    description: |
+      Specify an optional "change log" for the deployment.
+    is_required: false
+    title: Description
+- options: null
+  opts:
+    description: |
+      Any extra options that you would like to concat to the release-react command. Eg. "-m --disable-duplicate-release-error"
+    is_required: false
+    title: Extra Options


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2924)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
