### PR TITLE
smart-qa 0.0.1

### DIFF
--- a/steps/smart-qa/0.0.1/step.yml
+++ b/steps/smart-qa/0.0.1/step.yml
@@ -1,0 +1,53 @@
+title: SmartQA
+summary: |
+  SmartQA App.
+description: |
+  Deploy build to SmartQA.
+website: https://github.com/Levetty/bitrise-step-smartqa
+source_code_url: https://github.com/Levetty/bitrise-step-smartqa
+support_url: https://github.com/Levetty/bitrise-step-smartqa/issues
+published_at: 2021-03-18T23:07:08.7089+09:00
+source:
+  git: https://github.com/Levetty/bitrise-step-smartqa.git
+  commit: e5bd281f1a0f4c2d5d8a4aa63b0175b25a9b62bb
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- ios
+type_tags:
+- test
+toolkit:
+  go:
+    package_name: github.com/Levetty/bitrise-step-smartqa
+deps:
+  brew:
+  - name: git
+  - name: wget
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- build_path: null
+  opts:
+    description: |
+      Description of this input.
+      Can be Markdown formatted text.
+    is_expand: true
+    is_required: true
+    summary: Your application build path.
+    title: Build Path
+- api_key: null
+  opts:
+    description: |
+      Description of this input.
+      Can be Markdown formatted text.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: Your API Key.
+    title: API KEY

--- a/steps/smart-qa/0.0.1/step.yml
+++ b/steps/smart-qa/0.0.1/step.yml
@@ -1,15 +1,15 @@
 title: SmartQA
 summary: |
-  SmartQA App.
+  SmartQA E2E test step.
 description: |
-  Deploy build to SmartQA.
+  Deploy build to SmartQA. (https://smart-qa.io)
 website: https://github.com/Levetty/bitrise-step-smartqa
 source_code_url: https://github.com/Levetty/bitrise-step-smartqa
 support_url: https://github.com/Levetty/bitrise-step-smartqa/issues
-published_at: 2021-03-18T23:07:08.7089+09:00
+published_at: 2021-03-21T20:33:43.550291+09:00
 source:
   git: https://github.com/Levetty/bitrise-step-smartqa.git
-  commit: e5bd281f1a0f4c2d5d8a4aa63b0175b25a9b62bb
+  commit: 5ac7d12e24f37c0578b142918392c8fab672326c
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -20,13 +20,6 @@ type_tags:
 toolkit:
   go:
     package_name: github.com/Levetty/bitrise-step-smartqa
-deps:
-  brew:
-  - name: git
-  - name: wget
-  apt_get:
-  - name: git
-  - name: wget
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
@@ -35,8 +28,7 @@ inputs:
 - build_path: null
   opts:
     description: |
-      Description of this input.
-      Can be Markdown formatted text.
+      Path to your .app file.
     is_expand: true
     is_required: true
     summary: Your application build path.
@@ -44,8 +36,7 @@ inputs:
 - api_key: null
   opts:
     description: |
-      Description of this input.
-      Can be Markdown formatted text.
+      Access token to access SmartQA API.
     is_expand: true
     is_required: true
     is_sensitive: true

--- a/steps/smart-qa/step-info.yml
+++ b/steps/smart-qa/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2956)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.