### PR TITLE
comment-on-github-pull-request 0.10.0

### DIFF
--- a/steps/comment-on-github-pull-request/0.10.0/step.yml
+++ b/steps/comment-on-github-pull-request/0.10.0/step.yml
@@ -1,0 +1,67 @@
+title: Comment on GitHub Pull Request
+summary: |
+  Comment on [GitHub](https://github.com) Pull Request or Issue
+description: |
+  You can send a new or update an existing comment on [GitHub](https://github.com) Pull Request or Issue.
+
+  To setup a **GitHub personal access token** visit: https://github.com/settings/tokens
+website: https://github.com/kvvzr/bitrise-step-comment-on-github-pull-request
+source_code_url: https://github.com/kvvzr/bitrise-step-comment-on-github-pull-request
+support_url: https://github.com/kvvzr/bitrise-step-comment-on-github-pull-request/issues
+published_at: 2021-04-07T23:26:39.794231+09:00
+source:
+  git: https://github.com/kvvzr/bitrise-step-comment-on-github-pull-request.git
+  commit: 2be634ec1b191490629f7046da33986fb7ceb154
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+toolkit:
+  go:
+    package_name: github.com/kvvzr/bitrise-step-comment-on-github-pull-request
+is_requires_admin_user: true
+is_always_run: true
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      To setup a **GitHub personal access token** visit: https://github.com/settings/tokens
+      Add repo(Full control of private repositories) scope to the generated token, to allow to comment on GitHub Pull Request or Issue.
+    is_required: true
+    is_sensitive: true
+    title: GitHub personal access token
+  personal_access_token: null
+- body: null
+  opts:
+    description: |
+      Text of the message to send.
+    is_required: true
+    title: Body
+- opts:
+    description: |
+      The URL for target GitHub Repository.
+    is_required: true
+    title: Repository URL
+  repository_url: $GIT_REPOSITORY_URL
+- issue_number: $BITRISE_PULL_REQUEST
+  opts:
+    description: |
+      Number of GitHub Pull request or Issue.
+    is_required: true
+    title: GitHub PullRequest or Issue number
+- api_base_url: https://api.github.com
+  opts:
+    description: The URL for GitHub or GitHub Enterprise API
+    is_required: true
+    title: GitHub API Base URL
+- opts:
+    description: |
+      If set and a commment with the given tag exists, it updates the comment instead of posting a new one.
+      If no comment with the given tag exists, a new comment is posted.
+
+      The tag should be a unique string that will be added to end of the comment's content. The step automatically extends the tag to be enclosed in square brackets.
+    is_required: false
+    title: Update comment tag
+  update_comment_tag: null


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2983)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
