### PR TITLE
s3-download 1.2.0

### DIFF
--- a/steps/s3-download/1.2.0/step.yml
+++ b/steps/s3-download/1.2.0/step.yml
@@ -1,0 +1,66 @@
+title: S3 Download
+summary: This step allows to download a file from an S3 bucket.
+description: This step allows to download a file from an S3 bucket using an Access/secret
+  keypair for authentication.
+website: https://github.com/FutureWorkshops/bitrise-step-s3-download
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-s3-download
+published_at: 2021-04-15T17:35:05.765147+02:00
+source:
+  git: https://github.com/FutureWorkshops/bitrise-step-s3-download.git
+  commit: 91153ac6d6b39b83524d742fbefc1dbce43f0f32
+host_os_tags:
+- osx-10.10
+- osx-10.9
+type_tags:
+- utility
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- aws_access_key: ""
+  opts:
+    description: This is the AWS Access key of an user with read permission to the
+      S3 bucket/file.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: The Access Key for the S3 user
+    title: AWS Access Key
+- aws_secret_access_key: ""
+  opts:
+    description: This is the AWS Secret Access key of an user with read permission
+      to the S3 bucket/file.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: The Secret Access Key for the S3 user
+    title: AWS Secret Access Key
+- opts:
+    description: This is the S3 bucket containing the file to download
+    is_expand: true
+    is_required: true
+    summary: The S3 bucket containing the file to download
+    title: S3 Bucket
+  s3_bucket: ""
+- opts:
+    description: This is the file path of the file to download from the bucket.
+    is_expand: true
+    is_required: true
+    summary: The file path of the file to download
+    title: File path
+  s3_filepath: ""
+- opts:
+    description: The folder where to store the downloaded file (must exist).
+    is_expand: true
+    is_required: true
+    summary: Where to store the downloaded file.
+    title: File path
+  output_location: .
+outputs:
+- S3_DOWNLOAD_OUTPUT_PATH: null
+  opts:
+    description: This is the full path to the downloaded file. It will be composed
+      by resolved output_location and s3_filepath
+    summary: Path were the file was saved
+    title: S3 Download output


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=2994)

### Changelog

If the user requested a file in a sub-directory of the bucket, the output of the step would point to the wrong folder locally. This fix ensures that the output environment variable actually points to the right file. The step had its tests updated to validate this case.

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
