### PR TITLE
android-sdk-add-on-installer 0.0.1

### DIFF
--- a/steps/android-sdk-add-on-installer/0.0.1/step.yml
+++ b/steps/android-sdk-add-on-installer/0.0.1/step.yml
@@ -1,0 +1,77 @@
+title: Android SDK Add-on Installer
+summary: |
+  Step to install an Android SDK Add-on locally
+description: |
+  This step will download a specific version of the Android SDK Add-on into the Bitrise VM, allowing apps to build its code linking against this add-on code
+website: https://github.com/FutureWorkshops/bitrise-step-android-sdk-add-on-installer
+source_code_url: https://github.com/FutureWorkshops/bitrise-step-android-sdk-add-on-installer
+support_url: https://github.com/FutureWorkshops/bitrise-step-android-sdk-add-on-installer
+published_at: 2021-04-20T00:04:44.634593+02:00
+source:
+  git: https://github.com/FutureWorkshops/bitrise-step-android-sdk-add-on-installer.git
+  commit: e57e0115c2e2c2d000ab47d637d1c557429e7ec3
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- android
+- xamarin
+- react-native
+- cordova
+- ionic
+type_tags:
+- installer
+toolkit:
+  go:
+    package_name: github.com/FutureWorkshops/bitrise-step-android-sdk-add-on-installer
+deps:
+  brew:
+  - name: go
+  - name: unzip
+  apt_get:
+  - name: golang
+    bin_name: go
+  - name: unzip
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+inputs:
+- android_sdk_path: $ANDROID_HOME
+  opts:
+    is_expand: true
+    is_required: true
+    title: Path to the Android SDK folders in the machine
+- add_on_url: null
+  opts:
+    description: |
+      The Android SDK Manager Add-on definition is a XML file that is responsible to define how an extra is added to the
+      $ANDROID_HOME path.
+    is_expand: true
+    is_required: true
+    summary: URL to the android Add-on XML definition
+    title: Add-on URL
+- opts:
+    category: Debug
+    description: Enable verbose logging?
+    is_required: true
+    title: Enable verbose logging?
+    value_options:
+    - "yes"
+    - "no"
+  verbose_log: "no"
+- opts:
+    category: Debug
+    description: |-
+      If enabled, the step will calculate the checksum of the downloaded file, based in the type specified in the XML. If the local file
+      do not match the XML data, the step will fail.
+    is_required: true
+    title: Validate downloaded file checksum?
+    value_options:
+    - "yes"
+    - "no"
+  validate_checksum: "no"
+outputs:
+- ADD_ON_SDK_PATH: null
+  opts:
+    summary: Path to the installed SDK
+    title: Local Path of Addon

--- a/steps/android-sdk-add-on-installer/step-info.yml
+++ b/steps/android-sdk-add-on-installer/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3001)

### New Step functionality

The Android SDK can be extended with "extras", which are local maven repositories or fat AARs added to the `extra` folder of the `$ANDROID_HOME`. One example of this is the `intel` accelerators for emulators. Some library providers use this strategy to publish their code to clients, without having to publish the code into maven central.

This step downloads an XML file that conforms to the `http://schemas.android.com/sdk/android/addon` namespace, resolves its content, and installs in the Bitrise VM the archives indicated in the XML. The step also allows (optionally) to have the checksum of this content validated.

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.