### PR TITLE
Add trace sdk 1.2.4

### DIFF
--- a/steps/add-trace-sdk/1.2.4/step.yml
+++ b/steps/add-trace-sdk/1.2.4/step.yml
@@ -1,0 +1,54 @@
+title: Add Trace SDK iOS
+summary: |
+  ** Add the Trace SDK before the build process **
+
+  Important: Please read the Trace license terms in the SDK. By clicking here to add the Trace SDK, you are agreeing to those license terms.
+description: "Adds the Trace SDK static library during the Xcode build process into
+  the resulting app artifact.\n\niOS:\n  The step works by linking and modifying the
+  relevant Xcode project descriptor files to include necessary configurations in `other
+  linker flags`. These are the following:\n    - Trace static library path\n    -
+  System libraries: `C` and `C++` \n    - System Framework `SystemConfiguration.framework`\n
+  \ \n  System libraries and frameworks are linked if they are not present. It’s recommended
+  to add this step just before the Xcode build and archive step. \n  This step is
+  compatible with all Xcode projects that use Swift only, interoperability (mixed)
+  and Objective-C only languages. \n\n  Source code for the iOS SDK can be found here:
+  https://github.com/bitrise-io/trace-cocoa-sdk\n\n  Supported stack: Xcode 11 and
+  12\n\nAndroid:\nFor Android, please find the details below.\n**Source for Android
+  step:**\n[https://github.com/bitrise-steplib/bitrise-add-trace-sdk-android](https://github.com/bitrise-steplib/bitrise-add-trace-sdk-android)\n\n
+  \ \nOnce the app has been deployed, developers can view the results of the app in
+  the Trace addon.\n\nTrace: https://trace.bitrise.io\nWhat's Trace? https://www.bitrise.io/add-ons/trace-mobile-monitoring\nGetting
+  started guide: https://trace.bitrise.io/o/getting-started\n"
+website: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk
+support_url: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk/issues
+published_at: 2021-05-12T10:05:00.374908+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk.git
+  commit: f9da3d25560d7f393dbc1d8c662787e463e86d71
+project_type_tags:
+- ios
+type_tags:
+- utility
+is_requires_admin_user: false
+inputs:
+- opts:
+    description: A `.xcodeproj` or `.xcworkspace` path. Must be a relative path
+    is_required: true
+    summary: ""
+    title: Project (or Workspace) path
+  project_path: $BITRISE_PROJECT_PATH
+- opts:
+    description: The Scheme to use. For Apple related platforms only
+    is_required: true
+    summary: The Scheme to use. For Apple related platforms only
+    title: Scheme name
+  scheme: $BITRISE_SCHEME
+- lib_version: latest
+  opts:
+    description: |-
+      The version of the Bitrise Trace SDK to link into the app. Use `latest` to always download the most recent stable release.
+
+      List of available releases for Apple related platforms: https://github.com/bitrise-io/trace-cocoa-sdk/releases
+    is_required: true
+    summary: The version of the Bitrise Trace SDK to link into the app. See more https://github.com/bitrise-io/trace-cocoa-sdk/releases
+    title: Library version

--- a/steps/add-trace-sdk/1.2.4/step.yml
+++ b/steps/add-trace-sdk/1.2.4/step.yml
@@ -21,7 +21,7 @@ description: "Adds the Trace SDK static library during the Xcode build process i
 website: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk
 source_code_url: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk
 support_url: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk/issues
-published_at: 2021-05-12T10:05:00.374908+01:00
+published_at: 2021-05-12T10:07:10.552605+01:00
 source:
   git: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk.git
   commit: f9da3d25560d7f393dbc1d8c662787e463e86d71


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3034)

https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk/releases/1.2.4

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
