### PR TITLE
cocoapods-dependency-check 0.0.2

### DIFF
--- a/steps/cocoapods-dependency-check/0.0.2/step.yml
+++ b/steps/cocoapods-dependency-check/0.0.2/step.yml
@@ -1,0 +1,68 @@
+title: cocoapods-dependency-check
+summary: |
+  OWASP dependency analysis for iOS / CocoaPods
+description: |
+  Uses jeremylong/DependencyCheck to search Podfile.lock for CVE vulnerabilites.
+
+  The generated HTML document will be placed into BITRISE_DEPLOY_DIR by default.
+  Remember to run the "Deploy to bitrise.io" step in order to persist artifacts.
+website: https://github.com/johnjcsmith/bitrise-step-cocoapods-dependency-checker
+source_code_url: https://github.com/johnjcsmith/bitrise-step-cocoapods-dependency-checker
+support_url: https://github.com/johnjcsmith/bitrise-step-cocoapods-dependency-checker/issues
+published_at: 2021-05-20T21:00:56.062738+09:30
+source:
+  git: https://github.com/johnjcsmith/bitrise-step-cocoapods-dependency-checker.git
+  commit: b5a3e927b2a6d67a541e93ad979f46c2f57e56e5
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- dependency
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: dependency-check
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    is_required: true
+    title: Source Code Directory path
+  source_root_path: $BITRISE_SOURCE_DIR
+- app_title: $BITRISE_APP_TITLE
+  opts:
+    is_required: true
+    title: App title
+- deploy_dir: $BITRISE_DEPLOY_DIR
+  opts:
+    is_required: true
+    title: Deploy directory to output scan artifacts
+- opts:
+    description: |
+      (Optional) will default to $BITRISE_SOURCE_DIR/Podfile.lock
+    is_expand: true
+    is_required: false
+    summary: The path to your Podfile.lock file.
+    title: Podfile.lock path
+    value_options: []
+  podfile_lock_path: $BITRISE_SOURCE_DIR/Podfile.lock
+- fail_on_cvss_level: 11
+  opts:
+    description: |-
+      (Optional) Specifies if the build should be failed
+      if a CVSS score above a specified level is identified.
+
+      The default is 11; since
+      the CVSS scores are 0-10, by default the
+      build will never fail.
+    is_expand: true
+    is_required: false
+    summary: Sepcifies what level of CVSS should trigger a build failure
+    title: Fail on CVSS Level
+    value_options: []


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3046)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [👍] __I will not move an already shared step version's tag to another commit__
- [👍 ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ 👍] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ 👍] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ 👍] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
