### PR TITLE
Autify upload 0.0.1

### DIFF
--- a/steps/autify-upload/0.0.1/step.yml
+++ b/steps/autify-upload/0.0.1/step.yml
@@ -1,0 +1,69 @@
+title: |
+  Autify Upload
+summary: |
+  Uploads your build to Autify.
+description: |-
+  Uploads you build `.app` to [Autify](https://autify.com/mobile) using Autify's API. You can upload the iOS build with the Step.
+
+  This Step, however, does NOT generate your build: to create a `.app` file, you need the right step. For example, `Xcode build for simulator` Step or any other Step can generate a build. Add task URL
+website: https://github.com/autifyhq/bitrise-steps-autify-upload
+source_code_url: https://github.com/autifyhq/bitrise-steps-autify-upload
+support_url: https://github.com/autifyhq/bitrise-steps-autify-upload/issues
+published_at: 2021-06-02T05:10:23.914108+09:00
+source:
+  git: https://github.com/autifyhq/bitrise-step-autify-upload.git
+  commit: 5d9bc7aba74c96d11c5cd4098b82e1537350f5c9
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- android
+- xamarin
+- react-native
+- cordova
+- ionic
+- flutter
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- app_dir_path: $BITRISE_APP_DIR_PATH
+  opts:
+    description: |-
+      A `.app` path.
+
+      This path is generated in the previous step. For example:
+
+      - The `Xcode build for simulator` Step generate a app directory as `$BITRISE_APP_DIR_PATH`
+    is_required: true
+    summary: null
+    title: App directory path
+- opts:
+    description: |-
+      The Project ID can be found in the Auitify URL. For example:
+
+      - `autify.com/projects/<Project ID>`
+    is_required: true
+    summary: null
+    title: Autify project id
+  project_id: null
+- opts:
+    description: You can generate a Personal Access Token from Autify's Settings page.
+      Note that this value is associated with a specific user, as the name implies.
+    is_required: true
+    is_sensitive: true
+    summary: null
+    title: Autify Personal Access Token
+  upload_token: null
+outputs:
+- AUTIFY_UPLOAD_STEP_RESULT_JSON: null
+  opts:
+    description: This is the response to the API used to upload the build
+    summary: Response when uploading the build
+    title: Autify Upload Step Result JSON

--- a/steps/autify-upload/0.0.1/step.yml
+++ b/steps/autify-upload/0.0.1/step.yml
@@ -9,15 +9,14 @@ description: |-
 website: https://github.com/autifyhq/bitrise-steps-autify-upload
 source_code_url: https://github.com/autifyhq/bitrise-steps-autify-upload
 support_url: https://github.com/autifyhq/bitrise-steps-autify-upload/issues
-published_at: 2021-06-02T05:10:23.914108+09:00
+published_at: 2021-06-02T19:27:14.276215+09:00
 source:
   git: https://github.com/autifyhq/bitrise-step-autify-upload.git
-  commit: 5d9bc7aba74c96d11c5cd4098b82e1537350f5c9
+  commit: 4e2d9cdd6a278cbb08aaf9b8276438ed6b6e9396
 host_os_tags:
 - osx-10.10
 project_type_tags:
 - ios
-- android
 - xamarin
 - react-native
 - cordova

--- a/steps/autify-upload/0.0.1/step.yml
+++ b/steps/autify-upload/0.0.1/step.yml
@@ -6,13 +6,13 @@ description: |-
   Uploads you build `.app` to [Autify](https://autify.com/mobile) using Autify's API. You can upload the iOS build with the Step.
 
   This Step, however, does NOT generate your build: to create a `.app` file, you need the right step. For example, `Xcode build for simulator` Step or any other Step can generate a build. Add task URL
-website: https://github.com/autifyhq/bitrise-steps-autify-upload
-source_code_url: https://github.com/autifyhq/bitrise-steps-autify-upload
-support_url: https://github.com/autifyhq/bitrise-steps-autify-upload/issues
-published_at: 2021-06-02T19:27:14.276215+09:00
+website: https://github.com/autifyhq/bitrise-step-autify-upload
+source_code_url: https://github.com/autifyhq/bitrise-step-autify-upload
+support_url: https://github.com/autifyhq/bitrise-step-autify-upload/issues
+published_at: 2021-06-09T05:12:39.441439+09:00
 source:
   git: https://github.com/autifyhq/bitrise-step-autify-upload.git
-  commit: 4e2d9cdd6a278cbb08aaf9b8276438ed6b6e9396
+  commit: 15809911647ee0fad8527ee92810755b76faec14
 host_os_tags:
 - osx-10.10
 project_type_tags:
@@ -27,7 +27,6 @@ type_tags:
 toolkit:
   bash:
     entry_file: step.sh
-is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
 run_if: ""

--- a/steps/autify-upload/assets/icon.svg
+++ b/steps/autify-upload/assets/icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="256px" height="256px" viewBox="0 0 256 256" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Artboard</title>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="bg" fill="#FFFFFF" x="0" y="0" width="256" height="256"></rect>
+        <g id="logo" transform="translate(46.879078, 57.746176)">
+            <polygon id="Fill-2" fill="#00B398" points="149.738445 48.6170624 121.672653 97.2258304 106.096077 70.2459904 81.1130368 70.2459904 121.669581 140.491878 162.226125 70.2459904"></polygon>
+            <polygon id="Fill-3" fill="#000000" points="84.1984 118.861312 53.044736 118.861312 24.976384 70.245888 53.044736 21.630464 109.18144 21.630464 124.757504 48.60928 137.245184 26.978816 121.669632 0 40.556544 0 0 70.245888 40.556544 140.491776 96.686592 140.491776"></polygon>
+        </g>
+    </g>
+</svg>

--- a/steps/autify-upload/step-info.yml
+++ b/steps/autify-upload/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3071)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.