### PR TITLE
S3 cache pull 0.1.0

### DIFF
--- a/steps/s3-cache-pull/0.1.0/step.yml
+++ b/steps/s3-cache-pull/0.1.0/step.yml
@@ -1,0 +1,104 @@
+title: S3 Cache Pull
+summary: |
+  Download your cache from a S3 bucket using custom keys with fallback.
+website: https://github.com/alephao/bitrise-step-s3-cache-pull
+source_code_url: https://github.com/alephao/bitrise-step-s3-cache-pull
+support_url: https://github.com/alephao/bitrise-step-s3-cache-pull/issues
+published_at: 2021-06-01T13:22:50.350941-03:00
+source:
+  git: https://github.com/alephao/bitrise-step-s3-cache-pull.git
+  commit: 98a2b4001302f3d1e9309f57cdb788fb3b3d19b4
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/alephao/bitrise-step-s3-cache-pull
+deps:
+  brew:
+  - name: git
+  - name: wget
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- aws_access_key_id: $AWS_ACCESS_KEY_ID
+  opts:
+    category: AWS Access
+    is_expand: true
+    is_required: false
+    title: AWS_ACCESS_KEY_ID
+- aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+  opts:
+    category: AWS Access
+    is_expand: true
+    is_required: false
+    title: AWS_SECRET_ACCESS_KEY
+- aws_region: $AWS_S3_REGION
+  opts:
+    category: AWS Bucket
+    is_expand: true
+    is_required: true
+    summary: 'The region on AWS. E.g.: us-east-1'
+    title: AWS Region
+    value_options:
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+    - ca-central-1
+    - eu-north-1
+    - eu-west-3
+    - eu-west-2
+    - eu-west-1
+    - eu-central-1
+    - eu-south-1
+    - ap-south-1
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-northeast-3
+    - ap-southeast-1
+    - ap-southeast-2
+    - ap-east-1
+    - sa-east-1
+    - cn-north-1
+    - cn-northwest-1
+    - us-gov-east-1
+    - us-gov-west-1
+    - us-gov-secret-1
+    - us-gov-topsecret-1
+    - me-south-1
+    - af-south-1
+- bucket_name: $S3_BUCKET_NAME
+  opts:
+    category: AWS Bucket
+    is_expand: true
+    is_required: true
+    summary: The bucket name where you cache is stored
+    title: Bucket Name
+- opts:
+    category: Cache
+    description: "You can use '{{ checksum path/to/file }}' to get the file's sha256
+      checksum.      \nYou can use '{{ branch }}' to get the name of the current branch.\nE.g.:\nrestore_keys:
+      |\n  carthage-{{ branch }}-{{ checksum \"Cartfile.resolved\" }}\n  carthage-\n"
+    is_expand: false
+    is_required: true
+    summary: List of keys with fallbacks to restore the cache, one per line
+    title: Cache restore keys
+  restore_keys: null
+- opts:
+    category: Cache
+    description: |
+      path: ./
+    is_expand: false
+    is_required: true
+    summary: Path to extract the file or directory cached. Relative to the root of
+      the git repo.
+    title: Cache path
+  path: null

--- a/steps/s3-cache-pull/0.1.0/step.yml
+++ b/steps/s3-cache-pull/0.1.0/step.yml
@@ -1,13 +1,24 @@
 title: S3 Cache Pull
 summary: |
-  Download your cache from a S3 bucket using custom keys with fallback.
+  A step to retrieve your cache from a S3 bucket using custom keys with fallback.
+
+  This should be used with the s3-cache-push step to store the cache.
+
+  If you want to retrieve multiple items, you'll need run this step multiple times.
+
+  *Bucket Access*
+  For this step to work you'll need an user in aws with programmatic access to a bucket.
+  The user should have permissions to list, get, and put objects in the bucket.
+
+  You can set the credentials using the Bitrise Secrets with the keys specified in the inputs
+  or set them directly in the inputs.
 website: https://github.com/alephao/bitrise-step-s3-cache-pull
 source_code_url: https://github.com/alephao/bitrise-step-s3-cache-pull
 support_url: https://github.com/alephao/bitrise-step-s3-cache-pull/issues
-published_at: 2021-06-01T13:22:50.350941-03:00
+published_at: 2021-06-24T12:20:12.105573-03:00
 source:
   git: https://github.com/alephao/bitrise-step-s3-cache-pull.git
-  commit: 98a2b4001302f3d1e9309f57cdb788fb3b3d19b4
+  commit: 5a060fbe7421a60a272ae51a5f668b2e8e05b804
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -16,36 +27,43 @@ type_tags:
 toolkit:
   go:
     package_name: github.com/alephao/bitrise-step-s3-cache-pull
-deps:
-  brew:
-  - name: git
-  - name: wget
-  apt_get:
-  - name: git
-  - name: wget
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
 run_if: ""
 inputs:
-- aws_access_key_id: $AWS_ACCESS_KEY_ID
+- cache_aws_access_key_id: $CACHE_AWS_ACCESS_KEY_ID
   opts:
     category: AWS Access
+    description: |
+      The access key id that matches the secret access key.
+
+      The credentials need to be from a user that has at least the following permissions
+      in the bucket specified bellow `s3:ListObjects`, `s3:PutObject`, and `s3:GetObject`.
     is_expand: true
-    is_required: false
+    is_required: true
+    is_sensitive: true
+    summary: The AWS_ACCESS_KEY_ID to access the bucket.
     title: AWS_ACCESS_KEY_ID
-- aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+- cache_aws_secret_access_key: $CACHE_AWS_SECRET_ACCESS_KEY
   opts:
     category: AWS Access
+    description: |
+      The secret access key that matches the access key id.
+
+      The credentials need to be from a user that has at least the following permissions
+      in the bucket specified bellow `s3:ListObjects`, `s3:PutObject`, and `s3:GetObject`.
     is_expand: true
-    is_required: false
+    is_required: true
+    is_sensitive: true
+    summary: The AWS_SECRET_ACCESS_KEY to access the bucket.
     title: AWS_SECRET_ACCESS_KEY
-- aws_region: $AWS_S3_REGION
+- cache_aws_region: $CACHE_AWS_S3_REGION
   opts:
     category: AWS Bucket
     is_expand: true
     is_required: true
-    summary: 'The region on AWS. E.g.: us-east-1'
+    summary: The region of the S3 bucket
     title: AWS Region
     value_options:
     - us-east-1
@@ -75,30 +93,51 @@ inputs:
     - us-gov-topsecret-1
     - me-south-1
     - af-south-1
-- bucket_name: $S3_BUCKET_NAME
+- cache_bucket_name: $CACHE_S3_BUCKET_NAME
   opts:
     category: AWS Bucket
     is_expand: true
     is_required: true
-    summary: The bucket name where you cache is stored
+    summary: The name of the s3 bucket where you want to store the cache
     title: Bucket Name
-- opts:
-    category: Cache
-    description: "You can use '{{ checksum path/to/file }}' to get the file's sha256
-      checksum.      \nYou can use '{{ branch }}' to get the name of the current branch.\nE.g.:\nrestore_keys:
-      |\n  carthage-{{ branch }}-{{ checksum \"Cartfile.resolved\" }}\n  carthage-\n"
-    is_expand: false
-    is_required: true
-    summary: List of keys with fallbacks to restore the cache, one per line
-    title: Cache restore keys
-  restore_keys: null
-- opts:
+- cache_restore_keys: null
+  opts:
     category: Cache
     description: |
-      path: ./
+      The cache key can contain special values for convenience.
+
+      You can use '{{ checksum path/to/file }}' to get the file content's sha256 checksum.
+      You can use '{{ branch }}' to get the name of the current branch.
+      You can use '{{ stackrev }}' to get the machine's stack id.
+
+      This step will loop through the specified keys and retrieve the cache for the first
+      key that matches the prefix of a cache key. For example:
+
+      If you only have a cache stored with the key `carthage-a-b-c` and the following restore Keys:
+
+      cache_restore_keys: |
+        carthage-a-b-123
+        carthage-a-123
+        carthage-
+        car
+
+      It will try looking for a key prefixed with `carthage-a-b-123` and will find nothing. Then
+      it will try the same for `carthage-a-123` and will find nothing. Then it will try the same for
+      `carthage-` and it will find our cache `carthage-a-b-c` and retrieve it.
+
+      If a cache is not found for the key, this step is skipped.
+    is_expand: false
+    is_required: true
+    summary: List of cache key prefixes to find the cached file
+    title: Cache restore keys
+- cache_path: null
+  opts:
+    category: Cache
+    description: |
+      If you stored the cache as `/path/to/my/folder`, the compressed file in the bucket will contain
+      only `folder`, therefore you'll need to set this to `/path/to/my/`
     is_expand: false
     is_required: true
     summary: Path to extract the file or directory cached. Relative to the root of
       the git repo.
     title: Cache path
-  path: null

--- a/steps/s3-cache-pull/step-info.yml
+++ b/steps/s3-cache-pull/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3087)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

### Obs.:

In my previous PR I got the feedback to remove the env variables like `cache_aws_access_key_id: $CACHE_AWS_ACCESS_KEY_ID`, but that's needed on my use case because I get some of the inputs from the Bitrise Secrets.

**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.