### PR TITLE
List jira tickets 0.0.1

### DIFF
--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -1,15 +1,15 @@
 title: JIRA tickets listing
 summary: |
-  List all JIRA tickets by comparing two branches.
+  Lists all JIRA tickets by comparing two branches.
 description: |
-  List all JIRA tickets by comparing two branches. It will output either a list of ticket IDs or links if you add the URL path.
+  Lists all JIRA tickets by comparing two branches. It uses the JIRA ticket prefix to parse the commit messages. It will output either a list of ticket IDs or links if you add the URL path.
 website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
-published_at: 2021-07-29T12:52:41.698999-04:00
+published_at: 2021-08-17T15:06:23.132933-04:00
 source:
   git: https://amarliac@bitbucket.org/silofit/bitrise-jira-tickets.git
-  commit: e8c4581b452ac2912bc34588549a2040fb3d6035
+  commit: 71564b541d2d52a93e87b06bfe075abd219fdf84
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -54,11 +54,11 @@ inputs:
   url_path: null
 - opts:
     description: |
-      JIRA ticket's Prefix
+      JIRA ticket's prefix is necessary to extract the tickets when parsing the commit messages. It is following the pattern: [prefix]-[ticket number]. Example: "JTS" as a prefix will extract JIRA tickets like "JTS-1234"
     is_expand: true
     is_required: true
     summary: null
-    title: JIRA ticket's Prefix
+    title: JIRA ticket's prefix
   prefix: null
 outputs:
 - JIRA_TICKET_IDS: null

--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
-published_at: 2021-08-17T15:06:23.132933-04:00
+published_at: 2021-08-17T15:09:12.991958-04:00
 source:
   git: https://amarliac@bitbucket.org/silofit/bitrise-jira-tickets.git
   commit: 71564b541d2d52a93e87b06bfe075abd219fdf84

--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
-published_at: 2021-08-17T15:09:12.991958-04:00
+published_at: 2021-08-18T11:50:16.763155-04:00
 source:
-  git: https://amarliac@bitbucket.org/silofit/bitrise-jira-tickets.git
-  commit: 71564b541d2d52a93e87b06bfe075abd219fdf84
+  git: https://bitbucket.org/silofit/bitrise-jira-tickets.git
+  commit: dde15e6fac17cceca6fabbe8bcebbd55ce27f043
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04

--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -1,0 +1,69 @@
+title: JIRA tickets listing
+summary: |
+  List all JIRA tickets by comparing two branches.
+description: |
+  List all JIRA tickets by comparing two branches. It will output either a list of ticket IDs or links if you add the URL path.
+website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
+source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
+support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
+published_at: 2021-07-29T12:52:41.698999-04:00
+source:
+  git: https://amarliac@bitbucket.org/silofit/bitrise-jira-tickets.git
+  commit: e8c4581b452ac2912bc34588549a2040fb3d6035
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  apt_get:
+  - name: git
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: |
+      This is the branch you will be listing the JIRA tickets from.
+    is_expand: true
+    is_required: true
+    summary: null
+    title: Selected Git branch
+  selected_branch: null
+- opts:
+    description: |
+      This is the branch you will be comparing your selected branch with to list the JIRA tickets.
+    is_expand: true
+    is_required: true
+    summary: null
+    title: Reference Git branch
+  reference_branch: null
+- opts:
+    description: |
+      Adding the URL path of your JIRA workspace will output the ticket links instead of just a list of IDs.
+    is_expand: true
+    is_required: false
+    summary: null
+    title: JIRA ticket's URL path
+  url_path: null
+- opts:
+    description: |
+      JIRA ticket's Prefix
+    is_expand: true
+    is_required: true
+    summary: null
+    title: JIRA ticket's Prefix
+  prefix: null
+outputs:
+- JIRA_TICKET_IDS: null
+  opts:
+    description: |
+      List of JIRA ticket IDs found on the selected branch.
+    summary: null
+    title: JIRA ticket IDs

--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
-published_at: 2021-08-18T11:50:16.763155-04:00
+published_at: 2021-08-18T11:54:17.924458-04:00
 source:
   git: https://bitbucket.org/silofit/bitrise-jira-tickets.git
-  commit: dde15e6fac17cceca6fabbe8bcebbd55ce27f043
+  commit: a59e403918adf3355de2b3bc67b81d03cc1531b9
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -61,9 +61,9 @@ inputs:
     title: JIRA ticket's prefix
   prefix: null
 outputs:
-- JIRA_TICKET_IDS: null
+- JIRA_TICKET_ID_LIST: null
   opts:
     description: |
       List of JIRA ticket IDs found on the selected branch.
     summary: null
-    title: JIRA ticket IDs
+    title: List of JIRA ticket IDs

--- a/steps/list-jira-tickets/0.0.1/step.yml
+++ b/steps/list-jira-tickets/0.0.1/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 source_code_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
 support_url: https://bitbucket.org/silofit/bitrise-jira-tickets/src/master/
-published_at: 2021-08-18T11:54:17.924458-04:00
+published_at: 2021-08-19T09:42:54.933566-04:00
 source:
   git: https://bitbucket.org/silofit/bitrise-jira-tickets.git
-  commit: a59e403918adf3355de2b3bc67b81d03cc1531b9
+  commit: d9f82bd4007043bf28640c3e5e7370b4a088d8d3
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04

--- a/steps/list-jira-tickets/step-info.yml
+++ b/steps/list-jira-tickets/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3180)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.