### PR TITLE
dropbox-upload-v2 0.0.1

### DIFF
--- a/steps/dropbox-upload-v2/0.0.1/step.yml
+++ b/steps/dropbox-upload-v2/0.0.1/step.yml
@@ -9,7 +9,7 @@ support_url: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2/issu
 published_at: 2021-08-23T11:22:49.406953+03:00
 source:
   git: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2.git
-  commit: a49c479c146cf3e54dec42d3696799dc299734b1
+  commit: aa75400f66b7f21f7199f6fa3ca6f09692b37f0d
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04

--- a/steps/dropbox-upload-v2/0.0.1/step.yml
+++ b/steps/dropbox-upload-v2/0.0.1/step.yml
@@ -1,0 +1,62 @@
+title: dropbox-upload-v2
+summary: |
+  upload a file to dropbox and get a shareable link in return
+description: |
+  using this step you can send downloadable links via any platform
+website: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2
+source_code_url: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2
+support_url: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2/issues
+published_at: 2021-08-23T11:22:49.406953+03:00
+source:
+  git: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2.git
+  commit: 2318720f9328cd0ffa61018f096aa6fdceceef16
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  - name: wget
+  apt_get:
+  - name: git
+  - name: wget
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- dropbox_secret: null
+  opts:
+    description: |
+      You have to generate a secret access token in [the developer website](https://www.dropbox.com/developers).
+      Create an application and go in the setting's application.
+    is_required: true
+    title: The secret access token (OAuth2)
+- dropbox_local_path: null
+  opts:
+    description: |
+      The name of the local file you wish to upload on dropbox.
+      * Only one file !
+      * If a remote file exist with the same name, the file is overwritten
+
+
+      **example :** "/tmp/myapp.ipa" or "/tmp/myapp.apk"
+    is_required: true
+    title: Local File
+- dropbox_remote_path: null
+  opts:
+    description: |
+      The directory to upload file in dropbox
+      * If you specify a directory that does not exist this one is created
+      **example :** "/delivery/ios" or "/delivery/android"
+    is_required: true
+    title: Dropbox remote target
+outputs:
+- FILE_SHARED_LINK: null
+  opts:
+    title: Shareable link for the uploaded file

--- a/steps/dropbox-upload-v2/0.0.1/step.yml
+++ b/steps/dropbox-upload-v2/0.0.1/step.yml
@@ -9,7 +9,7 @@ support_url: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2/issu
 published_at: 2021-08-23T11:22:49.406953+03:00
 source:
   git: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2.git
-  commit: 328cf9a232efcf656bd62fdf3bfd692c733b7f88
+  commit: a49c479c146cf3e54dec42d3696799dc299734b1
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -18,13 +18,6 @@ type_tags:
 toolkit:
   bash:
     entry_file: step.sh
-deps:
-  brew:
-  - name: git
-  - name: wget
-  apt_get:
-  - name: git
-  - name: wget
 is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
@@ -36,6 +29,7 @@ inputs:
       You have to generate a secret access token in [the developer website](https://www.dropbox.com/developers).
       Create an application and go in the setting's application.
     is_required: true
+    is_sensitive: true
     title: The secret access token (OAuth2)
 - dropbox_local_path: null
   opts:
@@ -52,11 +46,11 @@ inputs:
   opts:
     description: |
       The directory to upload file in dropbox
-      * If you specify a directory that does not exist this one is created
+      * If you specify a directory that does not exists this one is created
       **example :** "/delivery/ios" or "/delivery/android"
     is_required: true
     title: Dropbox remote target
 outputs:
-- FILE_SHARED_LINK: null
+- DROPBOX_FILE_SHARED_LINK: null
   opts:
     title: Shareable link for the uploaded file

--- a/steps/dropbox-upload-v2/0.0.1/step.yml
+++ b/steps/dropbox-upload-v2/0.0.1/step.yml
@@ -9,7 +9,7 @@ support_url: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2/issu
 published_at: 2021-08-23T11:22:49.406953+03:00
 source:
   git: https://github.com/AlexPinhasov/bitrise-step-dropbox-upload-v2.git
-  commit: 2318720f9328cd0ffa61018f096aa6fdceceef16
+  commit: 328cf9a232efcf656bd62fdf3bfd692c733b7f88
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3181)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.