### PR TITLE
set-java-version 1.0.1

### DIFF
--- a/steps/set-java-version/1.0.1/step.yml
+++ b/steps/set-java-version/1.0.1/step.yml
@@ -1,0 +1,49 @@
+title: Set java version
+summary: This step helps you in setting an already installed java version on the virtual
+  machine.
+description: |
+  This step helps you in setting an already installed java version on the virtual machine. Mind you, that this step can't install any java version, it's only for changing between the already installed versions.
+
+  If you want to install other java version you can do it by [this guide](https://devcenter.bitrise.io/infrastructure/virtual-machines/#switching-to-a-java-version-not-installed-on-our-android-stacks).
+
+  ### Troubleshooting
+
+  If the step fails to set the java version, you can use these [scripts](https://devcenter.bitrise.io/infrastructure/virtual-machines/#managing-java-versions) as a temporary workaround.
+
+  ### Useful links
+
+  [Managing Java versions on Bitrise](https://devcenter.bitrise.io/infrastructure/virtual-machines/#managing-java-versions)
+website: https://github.com/bitrise-steplib/bitrise-step-set-java-version
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-set-java-version
+support_url: https://github.com/bitrise-steplib/bitrise-step-set-java-version/issues
+published_at: 2021-09-03T12:36:38.394272+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-set-java-version.git
+  commit: cc12fd4eabb43a317d4b261f6d9010f0fe9eef3c
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-set-java-version
+is_always_run: false
+is_skippable: false
+inputs:
+- opts:
+    description: |
+      Select the installed java version you want to use during the build run.
+
+      You can check [here](https://github.com/bitrise-io/bitrise.io/tree/master/system_reports) which java versions are installed on each Bitrise stack.
+    is_required: true
+    summary: Select the installed java version you want to use during the build run.
+    title: Java version to be set globally for the build
+    value_options:
+    - "11"
+    - "8"
+  set_java_version: "11"
+outputs:
+- JAVA_HOME: null
+  opts:
+    description: JAVA_HOME is an environment variable points to the file system location
+      where the JDK or JRE was installed.
+    summary: Location where the JDK or JRE was installed.
+    title: Location where the JDK or JRE was installed.

--- a/steps/set-java-version/step-info.yml
+++ b/steps/set-java-version/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/set-java-version/step-info.yml
+++ b/steps/set-java-version/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3200)

https://github.com/bitrise-steplib/bitrise-step-set-java-version/releases/1.0.1

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.