### PR TITLE
[MOB-222] Add deprecation note to Xamarin steps

### DIFF
--- a/steps/nuget-restore/step-info.yml
+++ b/steps/nuget-restore/step-info.yml
@@ -1,1 +1,5 @@
+deprecate_notes: |
+  The Xamarin development platform is not officially supported.
+  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
 maintainer: bitrise
+removal_date: "2022-05-01"

--- a/steps/xamarin-android-test/step-info.yml
+++ b/steps/xamarin-android-test/step-info.yml
@@ -1,1 +1,5 @@
+deprecate_notes: |
+  The Xamarin development platform is not officially supported.
+  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
 maintainer: bitrise
+removal_date: "2022-05-01"

--- a/steps/xamarin-archive/step-info.yml
+++ b/steps/xamarin-archive/step-info.yml
@@ -1,1 +1,5 @@
+deprecate_notes: |
+  The Xamarin development platform is not officially supported.
+  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
 maintainer: bitrise
+removal_date: "2022-05-01"

--- a/steps/xamarin-components-restore/step-info.yml
+++ b/steps/xamarin-components-restore/step-info.yml
@@ -1,1 +1,5 @@
+deprecate_notes: |
+  The Xamarin development platform is not officially supported.
+  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise 
 maintainer: bitrise
+removal_date: "2022-05-01"

--- a/steps/xamarin-ios-test/step-info.yml
+++ b/steps/xamarin-ios-test/step-info.yml
@@ -1,1 +1,5 @@
+deprecate_notes: |
+  The Xamarin development platform is not officially supported.
+  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise 
 maintainer: bitrise
+removal_date: "2022-05-01"


### PR DESCRIPTION
The following Xamarin steps are marked as deprecated:
- nuget-restore
- xamarin-android-test
- xamarin-ios-test
- xamarin-archive
- xamarin-components-restore
