### PR TITLE
Xcode result bundle to checks 1.1.0

### DIFF
--- a/steps/xcode-result-bundle-to-checks/1.1.0/step.yml
+++ b/steps/xcode-result-bundle-to-checks/1.1.0/step.yml
@@ -1,0 +1,96 @@
+title: Xcode Result Bundle to GitHub Checks
+summary: |
+  Generates a human-readable test report from the Xcode result bundle and shows it on GitHub Checks.
+description: |
+  Generates a human-readable test report from the Xcode result bundle and shows it on GitHub Checks.
+website: https://github.com/kishikawakatsumi/bitrise-step-xcode-result-bundle-to-checks
+source_code_url: https://github.com/kishikawakatsumi/bitrise-step-xcode-result-bundle-to-checks
+support_url: https://github.com/kishikawakatsumi/bitrise-step-xcode-result-bundle-to-checks/issues
+published_at: 2021-10-25T19:38:24.734504+09:00
+source:
+  git: https://github.com/kishikawakatsumi/bitrise-step-xcode-result-bundle-to-checks.git
+  commit: 69941364c7292e18db3f71c2a6acb4ad2f9fb723
+project_type_tags:
+  - ios
+  - macos
+type_tags:
+  - test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+    - name: node
+is_always_run: true
+is_skippable: true
+run_if: .IsCI
+inputs:
+  - xcresult_path: $BITRISE_XCRESULT_PATH
+    opts:
+      description: |
+        Path to the xcresult bundle.
+      is_expand: true
+      is_required: true
+      summary: Path to the xcresult bundle.
+      title: Result bundle path
+
+  - title: Xcode test results
+    opts:
+      description: |
+        Title for the check results.
+      is_expand: true
+      is_required: false
+      summary: Title for the check results.
+      title: Title
+
+  - show_passed_tests: true
+    opts:
+      description: |
+        Whether to show passed tests.
+      is_expand: true
+      is_required: false
+      summary: Whether to show passed tests.
+      title: Show passed tests
+      value_options:
+        - "false"
+        - "true"
+
+  - show_code_coverage: true
+    opts:
+      description: |
+        Whether to show code coverage.
+      is_expand: true
+      is_required: false
+      summary: Whether to show code coverage.
+      title: Show code coverage
+      value_options:
+        - "false"
+        - "true"
+
+  - github_owner: $BITRISEIO_GIT_REPOSITORY_OWNER
+    opts:
+      description: |
+        The name of the owner of the GitHub repository.
+      is_expand: true
+      is_required: false
+      summary: The name of the GitHub repository.
+      title: GitHub repository owner
+
+  - github_repo: $BITRISEIO_GIT_REPOSITORY_SLUG
+    opts:
+      description: |
+        The name of the GitHub repository.
+      is_expand: true
+      is_required: false
+      summary: The name of the GitHub repository.
+      title: GitHub repository
+
+  - head_sha: $GIT_CLONE_COMMIT_HASH
+    opts:
+      description: |
+        The SHA of the commit to check.
+      is_expand: true
+      is_required: false
+      is_dont_change_value: true
+      summary: The SHA of the commit to check.
+      title: Commit SHA-1 Hash


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3295)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
