### PR TITLE
Addded deprecation notice for auto provision Steps

### DIFF
--- a/steps/ios-auto-provision-appstoreconnect/step-info.yml
+++ b/steps/ios-auto-provision-appstoreconnect/step-info.yml
@@ -1,11 +1,18 @@
 maintainer: bitrise
 removal_date: "2022-07-15"
 deprecate_notes: |
-  This Step has been deprecated in the favour of the new automatic code signing options on Bitrise.
+  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.')
+
   Option A)
-  The latest versions of the 'Xcode Archive & Export for iOS', 'Xcode Build for testing for iOS',  and the 'Export iOS and tvOS Xcode archive' steps have built-in automatic code signing.
-  We suggest to remove this step from your workflow and start to use  the automatic code signing feature in the Steps mentioned above.
+  The latest versions of the **Xcode Archive & Export for iOS**,
+  **Xcode Build for testing for iOS**,
+  and the **Export iOS and tvOS Xcode archive** Steps
+  have built-in automatic code signing.
+  We recommend removing this Step from your Workflow and using the automatic code signing feature in the Steps mentioned above.
+
   Option B)
-  If you are not using any of the mentioned Xcode steps, then you can replace this Step with the 'Manage iOS Code signing' Step.
+  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with
+  the **Manage iOS Code signing** (https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
+
   You can read more about these changes in our blog post:
-  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise.
+  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise

--- a/steps/ios-auto-provision-appstoreconnect/step-info.yml
+++ b/steps/ios-auto-provision-appstoreconnect/step-info.yml
@@ -1,7 +1,7 @@
 maintainer: bitrise
 removal_date: "2022-07-15"
 deprecate_notes: |
-  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.')
+  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.
 
   Option A)
   The latest versions of the **Xcode Archive & Export for iOS**,

--- a/steps/ios-auto-provision-appstoreconnect/step-info.yml
+++ b/steps/ios-auto-provision-appstoreconnect/step-info.yml
@@ -1,1 +1,11 @@
 maintainer: bitrise
+removal_date: "2022-07-15"
+deprecate_notes: |
+  This Step has been deprecated in the favour of the new automatic code signing options on Bitrise.
+  Option A)
+  The latest versions of the 'Xcode Archive & Export for iOS', 'Xcode Build for testing for iOS',  and the 'Export iOS and tvOS Xcode archive' steps have built-in automatic code signing.
+  We suggest to remove this step from your workflow and start to use  the automatic code signing feature in the Steps mentioned above.
+  Option B)
+  If you are not using any of the mentioned Xcode steps, then you can replace this Step with the 'Manage iOS Code signing' Step.
+  You can read more about these changes in our blog post:
+  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise.

--- a/steps/ios-auto-provision/step-info.yml
+++ b/steps/ios-auto-provision/step-info.yml
@@ -1,11 +1,18 @@
 maintainer: bitrise
 removal_date: "2022-07-15"
 deprecate_notes: |
-  This Step has been deprecated in the favour of the new automatic code signing options on Bitrise.
+  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.')
+
   Option A)
-  The latest versions of the 'Xcode Archive & Export for iOS', 'Xcode Build for testing for iOS',  and the 'Export iOS and tvOS Xcode archive' steps have built-in automatic code signing.
-  We suggest to remove this step from your workflow and start to use  the automatic code signing feature in the Steps mentioned above.
+  The latest versions of the **Xcode Archive & Export for iOS**,
+  **Xcode Build for testing for iOS**,
+  and the **Export iOS and tvOS Xcode archive** Steps
+  have built-in automatic code signing.
+  We recommend removing this Step from your Workflow and using the automatic code signing feature in the Steps mentioned above.
+
   Option B)
-  If you are not using any of the mentioned Xcode steps, then you can replace this Step with the 'Manage iOS Code signing' Step.
+  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with
+  the **Manage iOS Code signing** (https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
+
   You can read more about these changes in our blog post:
-  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise.
+  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise

--- a/steps/ios-auto-provision/step-info.yml
+++ b/steps/ios-auto-provision/step-info.yml
@@ -1,7 +1,7 @@
 maintainer: bitrise
 removal_date: "2022-07-15"
 deprecate_notes: |
-  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.')
+  This Step has been deprecated in favour of the new automatic code signing options on Bitrise.
 
   Option A)
   The latest versions of the **Xcode Archive & Export for iOS**,

--- a/steps/ios-auto-provision/step-info.yml
+++ b/steps/ios-auto-provision/step-info.yml
@@ -1,1 +1,11 @@
 maintainer: bitrise
+removal_date: "2022-07-15"
+deprecate_notes: |
+  This Step has been deprecated in the favour of the new automatic code signing options on Bitrise.
+  Option A)
+  The latest versions of the 'Xcode Archive & Export for iOS', 'Xcode Build for testing for iOS',  and the 'Export iOS and tvOS Xcode archive' steps have built-in automatic code signing.
+  We suggest to remove this step from your workflow and start to use  the automatic code signing feature in the Steps mentioned above.
+  Option B)
+  If you are not using any of the mentioned Xcode steps, then you can replace this Step with the 'Manage iOS Code signing' Step.
+  You can read more about these changes in our blog post:
+  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise.


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [-] __I will not move an already shared step version's tag to another commit__
- [-] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [-] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [-] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [-] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
