### PR TITLE
Make Nowsecure verified

### DIFF
--- a/steps/bitrise-step-nowsecure-auto-analysis/step-info.yml
+++ b/steps/bitrise-step-nowsecure-auto-analysis/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: verified


### PR DESCRIPTION
- CLA signed ✅ 
- Icon is still missing but will be delivered later in a separate PR.