### PR TITLE
aws-secrets-manager 2.1.0

### DIFF
--- a/steps/aws-secrets-manager/2.1.0/step.yml
+++ b/steps/aws-secrets-manager/2.1.0/step.yml
@@ -1,0 +1,103 @@
+title: Fetch secrets from AWS Secrets Manager
+summary: Fetch secrets from AWS Secrets Manager
+description: |
+  This Step fetches secrets on-demand from AWS Secrets Manager, during Bitrise workflow execution.
+
+  The fetched secrets are then propagated into subsequent steps in the workflow.
+
+  Include this Step in your workflow, for example:
+
+  ```yaml
+  workflows:
+    foo:
+      steps:
+      - aws-secrets-manager@x.x.x:
+          inputs:
+          - aws_access_key_id: $AWS_ACCESS_KEY_ID
+          - aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+          - aws_default_region: a-region-1
+          - secret_list: |
+              arn:aws:secret-1 # username # USERNAME
+              arn:aws:secret-2 # password # PASSWORD
+      - script@1:
+          inputs:
+          - content: |
+              #!/bin/bash
+              #
+              # Access your secrets via $USERNAME and $PASSWORD
+  ```
+
+  Checkout the main repository README for more usage guide.
+website: https://github.com/MoneyLion/bitrise-step-aws-secrets-manager
+source_code_url: https://github.com/MoneyLion/bitrise-step-aws-secrets-manager
+support_url: https://github.com/MoneyLion/bitrise-step-aws-secrets-manager/issues
+published_at: 2022-03-01T22:24:56.567286+08:00
+source:
+  git: https://github.com/MoneyLion/bitrise-step-aws-secrets-manager.git
+  commit: ca54ddf8f393d583dc302c25569073f6c08bd343
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: moneylion.com/security/bitrise-step-aws-secrets-manager
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+inputs:
+- aws_access_key_id: ""
+  opts:
+    description: AWS access key ID.
+    is_sensitive: true
+    summary: AWS access key ID.
+    title: AWS access key ID
+- aws_secret_access_key: ""
+  opts:
+    description: AWS secret access key.
+    is_sensitive: true
+    summary: AWS secret access key.
+    title: AWS secret access key
+- aws_default_region: ""
+  opts:
+    description: AWS region to operate in.
+    summary: AWS region to operate in.
+    title: AWS region
+- aws_profile: ""
+  opts:
+    description: An AWS named profile in shared configuration file.
+    summary: An AWS named profile in shared configuration file.
+    title: AWS named profile
+- aws_iam_role_arn: ""
+  opts:
+    description: The ARN of AWS IAM role to assume.
+    summary: The ARN of AWS IAM role to assume.
+    title: AWS IAM role ARN
+- opts:
+    description: |
+      A newline separated list of secrets to fetch from AWS Secrets Manager.
+
+      Each line is in the form of:
+
+      ```
+      <Secret ARN> # <JSON object key> # <Environment variable>
+      ```
+
+      For example, given the secret with an ARN `arn:aws:secret-1`, and a secret value:
+
+      ```
+      {
+        "username": "admin",
+        "password": "str0ngpassword"
+      }
+      ```
+
+      Specifying this line in the secret list:
+
+      ```
+      arn:aws:secret-1 # username # USERNAME
+      ```
+
+      Fetches the secret, retrieves the JSON value under the key `username`, and store that value in the `USERNAME` environment variable. `$USERNAME` will now contain the value `admin`.
+    is_required: true
+    summary: A list of secrets to fetch.
+    title: Secret list
+  secret_list: null


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3420)

### Changes

- Mark stored secret values as sensitive [[diff](https://github.com/MoneyLion/bitrise-step-aws-secrets-manager/compare/72b0bb599fa60abad1e423f92c6f4a969771106d..ca54ddf8f393d583dc302c25569073f6c08bd343)].

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
