### PR TITLE
run-spm-test-with-coverage 0.0.2

### DIFF
--- a/steps/run-spm-test-with-coverage/0.0.2/step.yml
+++ b/steps/run-spm-test-with-coverage/0.0.2/step.yml
@@ -1,0 +1,91 @@
+title: Run Swift Test With Code Coverage
+summary: |
+  Step that runs SPM tests on macOS, outputting an XUnit XML file and Code Coverage
+description: |
+  Step that runs "swift test" in the local directory and export the results as a XUnit XML file into Bitrise Test Plugin and provides in the outputs the Code Coverage JSON file
+website: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
+source_code_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
+support_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage/issues
+published_at: 2022-05-04T19:16:04.074345Z
+source:
+  git: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage.git
+  commit: 9733ce3244f93a3591493f12c630cc86637f1582
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+- macos
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  apt_get:
+  - name: git
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- PROJECT_DIR: $BITRISE_SOURCE_DIR
+  opts:
+    description: |
+      Path with the Swift Package Manager code
+    is_expand: true
+    is_required: true
+    summary: Path with the Swift Package Manager code
+    title: Project directory
+- TEST_NAME: SwiftTest
+  opts:
+    description: |
+      Name that will be used in the test information and generated files
+    is_expand: true
+    is_required: true
+    summary: Name that will be used in the test information and generated files
+    title: Test name
+- CONFIGURATION: debug
+  opts:
+    description: |
+      Allows setting either Release or Debug for the build action
+    is_expand: true
+    is_required: true
+    summary: Allows setting either Release or Debug for the build action
+    title: Build Configuration
+    value_options:
+    - release
+    - debug
+- SKIP_BUILD: "NO"
+  opts:
+    description: |
+      Sends a --skip-build flag into the `swift test` command
+    is_expand: true
+    is_required: true
+    summary: Run test without building
+    title: Run test without building
+    value_options:
+    - "YES"
+    - "NO"
+- BUILD_PATH: $BITRISE_SOURCE_DIR/.build
+  opts:
+    description: |
+      Path where the build files will be stored
+    is_expand: true
+    is_required: true
+    summary: Path where the build files will be stored
+    title: Build path
+outputs:
+- TEST_RESULT: null
+  opts:
+    description: |
+      XML file with the result of the tests
+    summary: XML file with the result of the tests
+    title: Test result
+- CODE_COVERAGE_RESULT: null
+  opts:
+    description: |
+      JSON file with the result of the code coverage report
+    summary: JSON file with the result of the code coverage report
+    title: Code Coverage result

--- a/steps/run-spm-test-with-coverage/step-info.yml
+++ b/steps/run-spm-test-with-coverage/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3466)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

### Step functionality

This step helps with the execution of `swift test` command on [Swift Package Manager (SPM)](https://www.swift.org/package-manager/) projects.

At the time of this PR, there is a similar step with id [swift-package-manager-test-for-mac](https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac) in the step lib, but the published step is limited because it does not export a test result file compatible with the "Test Result" plugin and does not provide the code coverage output.

The step being published on this PR can be used as:

```yml
- git::https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage.git@main:
   title: Run Swift Package Manager Tests
   inputs:
   - TEST_NAME: BitriseTest
   - PROJECT_DIR: $BITRISE_SOURCE_DIR
   - BUILD_PATH: $BITRISE_SOURCE_DIR/.build
   - CONFIGURATION: 'debug'
   - SKIP_BUILD: 'NO'
```

And will export 2 files: 

- TEST_RESULT: $BITRISE_DEPLOY_DIR/BitriseTest.xml
- CODE_COVERAGE_RESULT: $BITRISE_DEPLOY_DIR/BitriseTest_codecoverage.json

These 2 files are also made available in the folder `$BITRISE_TEST_RESULT_DIR/SwiftTest` to be integrated with the "Test  Reports" plugin. Example: [https://addons-testing.bitrise.io/builds/28cb8144-dfb6-4ecc-9a8f-75774b874fcf/summary?status=failed](https://addons-testing.bitrise.io/builds/28cb8144-dfb6-4ecc-9a8f-75774b874fcf/summary?status=failed)

**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.