### PR TITLE
run-spm-test-with-coverage 0.1.0

### DIFF
--- a/steps/run-spm-test-with-coverage/0.1.0/step.yml
+++ b/steps/run-spm-test-with-coverage/0.1.0/step.yml
@@ -1,0 +1,105 @@
+title: Run Swift Test With Code Coverage
+summary: |
+  Step that runs SPM tests on macOS, outputting an XML/HTML test result file and Code Coverage JSON file
+description: |
+  This step uses xcodebuild & xcpretty to run the macOS tests for the Swift Package Manager. The final files are
+  output in a structure compatible with the "Test Report" plugin and can be configured to be JUnit or HTML as output,
+  so the generated files are compatible with tools like Danger.
+  The Code coverage is always exported as a JSON file.
+website: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
+source_code_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
+support_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage/issues
+published_at: 2022-05-05T01:57:00.695762Z
+source:
+  git: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage.git
+  commit: 36faa6f6852fb0be0e1f0038413f7b01ef73c4de
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- macos
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: git
+  apt_get:
+  - name: git
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- PROJECT_DIR: $BITRISE_SOURCE_DIR
+  opts:
+    description: |
+      Path with the Swift Package Manager code
+    is_expand: true
+    is_required: true
+    summary: Path with the Swift Package Manager code
+    title: Project directory
+- TEST_NAME: SwiftTest
+  opts:
+    description: |
+      Name that will be used in the test information and generated files
+    is_expand: true
+    is_required: true
+    summary: Name that will be used in the test information and generated files
+    title: Test name
+- BUILD_PATH: $BITRISE_SOURCE_DIR/.build
+  opts:
+    description: |
+      Path where the build files will be stored
+    is_expand: true
+    is_required: true
+    summary: Path where the build files will be stored
+    title: Build path
+- CONFIGURATION: debug
+  opts:
+    deprecated: true
+    description: |
+      Allows setting either Release or Debug for the build action (Deprecated)
+    is_expand: true
+    is_required: false
+    summary: Allows setting either Release or Debug for the build action (Deprecated)
+    title: Build Configuration (Deprecated)
+    value_options:
+    - release
+    - debug
+- SKIP_BUILD: "NO"
+  opts:
+    description: |
+      Run test without building
+    is_expand: true
+    is_required: true
+    summary: Run test without building
+    title: Run test without building
+    value_options:
+    - "YES"
+    - "NO"
+- REPORTER: junit
+  opts:
+    description: |
+      Choose between a junit report or a html report
+    is_expand: true
+    is_required: true
+    summary: Choose between a junit report or a html report
+    title: xcpretty reporter
+    value_options:
+    - junit
+    - html
+outputs:
+- TEST_RESULT: null
+  opts:
+    description: |
+      XML file with the result of the tests
+    summary: XML file with the result of the tests
+    title: Test result
+- CODE_COVERAGE_RESULT: null
+  opts:
+    description: |
+      JSON file with the result of the code coverage report
+    summary: JSON file with the result of the code coverage report
+    title: Code Coverage result

--- a/steps/run-spm-test-with-coverage/step-info.yml
+++ b/steps/run-spm-test-with-coverage/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

### Step functionality

This step helps with the execution of [Swift Package Manager (SPM)](https://www.swift.org/package-manager/) project's tests.

At the time of this PR, there is a similar step with id [swift-package-manager-test-for-mac](https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac) in the step lib, but the published step has 2   major limitations: 

1. It does not export a test result file compatible with the "Test Result" plugin and does not provide the code coverage output.
2. It uses `swift test`, so its output is [not fully compatible with xcpretty](https://github.com/kitasuke/bitrise-step-swift-package-manager-test-for-mac/issues/1) result formatter

The step being published on this PR uses `xcodebuild` to run the tests and always exports code coverage, fixing the 2 limitations described above. The step can be used as:

```yml
- git::https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage.git@0.1.0:
   title: Run Swift Package Manager Tests
   inputs:
   - TEST_NAME: BitriseTest
   - PROJECT_DIR: $BITRISE_SOURCE_DIR
   - SKIP_BUILD: 'NO'
   - REPORTER: junit
```

And will export 2 files: 

- TEST_RESULT: $BITRISE_DEPLOY_DIR/BitriseTest.xml
- CODE_COVERAGE_RESULT: $BITRISE_DEPLOY_DIR/BitriseTest_codecoverage.json

These 2 files are also made available in the folder `$BITRISE_TEST_RESULT_DIR/SwiftTest` to be integrated with the "Test  Reports" plugin. Example: [https://addons-testing.bitrise.io/builds/787aa33c-bb5f-4e88-9f8c-0873f1a104de/summary?status=failed](https://addons-testing.bitrise.io/builds/787aa33c-bb5f-4e88-9f8c-0873f1a104de/summary?status=failed)

This is a re-submit, first done on PR #3467 