### PR TITLE
Mark duplicated step as deprecated

### DIFF
--- a/steps/bitrise-step-install-bundler/step-info.yml
+++ b/steps/bitrise-step-install-bundler/step-info.yml
@@ -1,1 +1,7 @@
 maintainer: community
+removal_date: "2022-05-10"
+depreacted_notes: |
+  This step is a duplicated of install-bundler: https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/install-bundler
+
+  It's recommended to update your step configuration to use the right step:
+  - install_bundler@1: {}


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

### Problem

The "Install specific bundler version" step is duplicated in the steplib:

<img width="819" alt="Screenshot 2022-05-10 at 17 21 13" src="https://user-images.githubusercontent.com/2117340/167665203-43b5a9e6-2889-4000-a0b1-99c59dc69839.png">

- Correct version: [https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/install-bundler](https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/install-bundler)
- Duplication: [https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/bitrise-step-install-bundler](https://github.com/bitrise-io/bitrise-steplib/tree/master/steps/bitrise-step-install-bundler)

### Solution

The invalid version is being marked as deprecated with a message guiding the user to use the correct version. The versions `1.1.0` to `1.1.2` that exist in the invalid step will continue existing and another PR, in the future, will be created to update the correct step.