### PR TITLE
deploygate--upload-app-bitrise-step 1.1.2

### DIFF
--- a/steps/deploygate--upload-app-bitrise-step/1.1.2/step.yml
+++ b/steps/deploygate--upload-app-bitrise-step/1.1.2/step.yml
@@ -1,0 +1,97 @@
+title: DeployGate Upload
+summary: |
+  Distribute your in-development iOS/Android apps to your developers or testers
+description: |
+  This is a step to upload your iOS/Android application to DeployGate. DeployGate enable to share in-development apps with others instantly. For more details, please read references in [DeployGate.com](https://deploygate.com/?locale=en)
+website: https://github.com/DeployGate/upload-app-bitrise-step
+source_code_url: https://github.com/DeployGate/upload-app-bitrise-step
+support_url: https://github.com/DeployGate/upload-app-bitrise-step/issues
+published_at: 2022-05-13T11:45:03.558427+09:00
+source:
+  git: https://github.com/DeployGate/upload-app-bitrise-step.git
+  commit: 45373ddadac3e3d019f24011fcb2d375a747f457
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- api_key: ""
+  opts:
+    description: The authorization token to be used when uploading app
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: User's API Key or Organization's API Key
+    title: 'DeployGate: API Key'
+- opts:
+    description: |
+      The owner name of this application
+    is_required: true
+    summary: User name or Organization name
+    title: 'DeployGate: Owner Name'
+  owner_name: ""
+- app_path: ""
+  opts:
+    description: |
+      App's binary file (IPA/APK/AAB) to be uploaded.
+      $BITRISE\_APK\_PATH, $BITRISE\_IPA\_PATH, and so on.
+    is_required: true
+    summary: App's binary file (IPA/APK/AAB) to be uploaded
+    title: App file path
+- message: ""
+  opts:
+    description: A short message to explain this version
+    is_required: false
+    summary: A short message to explain this version
+    title: 'DeployGate: Short Message'
+- distribution_key: ""
+  opts:
+    description: |
+      By specifying the distribution page's hash, that distribution page will be updated simultaneously.
+      The "xxxx" portion of the distributed page's URL like https://deploygate.com/distributions/xxxx
+    is_required: false
+    summary: The distribution key to be updated
+    title: 'DeployGate: Distribution Key'
+- distribution_name: ""
+  opts:
+    description: "Specify the name of the updated distribution page. \nIf none exists,
+      a new distribution page will be created. \nPossible uses include creating distribution
+      pages for each Git branch name.\n"
+    is_required: false
+    summary: The distribution name to be created or be updated
+    title: 'DeployGate: Distribution Name'
+- opts:
+    description: Message displayed during distribution page app updates
+    is_required: false
+    summary: Message displayed during distribution page app updates
+    title: 'DeployGate: Release Note'
+  release_note: ""
+- disable_notify: "false"
+  opts:
+    description: (iOS only) A setting of true disables Push notification emails.
+    is_required: false
+    summary: (iOS only) A setting of true disables Push notification emails.
+    title: 'DeployGate: Disable Notify'
+    value_options:
+    - "true"
+    - "false"
+outputs:
+- DEPLOYGATE_UPLOAD_APP_STEP_RESULT_JSON: null
+  opts:
+    description: The raw json which Upload API has returned
+    summary: The raw json which Upload API has returned. Available iff the request
+      has been sent to DeployGate server.
+    title: 'DeployGate: API result json'


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3478)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
