### PR TITLE
xcode-start-simulator 1.0.0

### DIFF
--- a/steps/xcode-start-simulator/1.0.0/step.yml
+++ b/steps/xcode-start-simulator/1.0.0/step.yml
@@ -1,0 +1,107 @@
+title: Start Xcode simulator
+summary: |
+  Starts an Xcode simulator.
+description: |
+  Starts an Xcode simulator.
+website: https://github.com/bitrise-steplib/bitrise-step-xcode-start-simulator
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-xcode-start-simulator
+support_url: https://github.com/bitrise-steplib/bitrise-step-xcode-start-simulator/issues
+published_at: 2022-06-22T14:22:26.095399+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-xcode-start-simulator.git
+  commit: 8ece3107ce5064335dcf752065cb2335fd33be30
+project_type_tags:
+- ios
+- react-native
+- flutter
+- cordova
+- ionic
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-xcode-start-simulator
+deps:
+  check_only:
+  - name: xcode
+is_always_run: false
+is_skippable: false
+inputs:
+- destination: platform=iOS Simulator,name=iPhone 8 Plus,OS=latest
+  opts:
+    description: |-
+      Destination specifier describes the simulator device to be started.
+
+      The input value uses the same format as xcodebuild's `-destination` option.
+    is_required: true
+    summary: Destination specifier describes the simulator device to be started.
+    title: Device destination specifier
+- opts:
+    category: Debugging
+    description: |-
+      When larger than 0, will wait for the simulator boot to complete.
+
+      Setting to larger than 0 makes it possible to detect hangs or timeouts when booting simulator.
+      If a timeout occurs, the `BITRISE_SIMULATOR_STATUS` output will be set to `hanged`.
+      A reccomended value is 90.
+
+      Using `0` (the default) enables the Simulator boot to occur in parallel to other Steps.
+    is_required: true
+    summary: When larger than 0, will wait for the simulator boot to complete.
+    title: Simulator boot timeout (in seconds)
+  wait_for_boot_timeout: 0
+- opts:
+    category: Debugging
+    is_required: true
+    summary: If this input is set, the Step will print additional logs for debugging.
+    title: Enable verbose logging
+    value_options:
+    - "yes"
+    - "no"
+  verbose_log: "no"
+- opts:
+    category: Debugging
+    description: |-
+      If enabled, will shutdown and erase a simulator's contents and settings.
+
+      This option is not needed when starting from a clean state on a CI build.
+      It may be used when running testing multiple apps on the same simulator or for making sure that the simulator is indeed in a clean state when an app fails to install due to an unexpected issue.
+
+      When enabled erasing contents takes about a second.
+    is_required: true
+    summary: If enabled, will shutdown and erase a simulator's contents and settings.
+    title: Shutdown and erase simulator before use
+    value_options:
+    - "yes"
+    - "no"
+  reset: "no"
+outputs:
+- BITRISE_SIMULATOR_STATUS: null
+  opts:
+    description: |
+      Set to true/false based on starting Xcode Simulator failed with an unrecoverable error.
+
+      Possible values are:
+      - `booted`
+      - `failed`
+      - `hanged`
+
+      It can be used to trigger a new build conditionally:
+
+      ```
+      is_always_run: true
+      run_if: '{{enveq "BITRISE_SIMULATOR_STATUS" "hanged"}}'
+      ```
+    title: Set to true/false based on starting Xcode Simulator failed with an unrecoverable
+      error.
+    value_options:
+    - booted
+    - failed
+    - hanged
+- BITRISE_XCODE_DESTINATION: null
+  opts:
+    description: |-
+      Device destination specifier
+
+      The destination specifer provided in the `destination` Input. It can be used as Input of other Steps, to avoid duplication.
+    title: Device destination specifier


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
