### PR TITLE
android-instrumented-test 0.1.0

### DIFF
--- a/steps/android-instrumented-test/0.1.0/step.yml
+++ b/steps/android-instrumented-test/0.1.0/step.yml
@@ -1,0 +1,53 @@
+title: Android Instrumented Test
+summary: Runs Instrumented tests on an existing APK
+description: Runs Instrumented tests on an existing APK
+website: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test
+support_url: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/issues
+published_at: 2022-06-28T08:38:59.19506-05:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test.git
+  commit: 30dd54e3850db8b804e5dcd3acae2cc19dbf924e
+project_type_tags:
+- android
+type_tags:
+- test
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-android-instrumented-test
+inputs:
+- main_apk_path: $BITRISE_APK_PATH
+  opts:
+    description: The path to the app's main APK
+    is_required: true
+    summary: The path to the app's main APK
+    title: Main APK path
+- opts:
+    description: The path to the app's test APK
+    is_required: true
+    summary: The path to the app's test APK
+    title: Test APK path
+  test_apk_path: $BITRISE_TEST_APK_PATH
+- opts:
+    description: The name of the test runner
+    is_required: true
+    summary: The name of the test runner
+    title: Test runner class
+  test_runner_class: androidx.test.runner.AndroidJUnitRunner
+- additional_testing_options: ""
+  opts:
+    description: |-
+      A space-delimited list of additional options to pass to the test runner
+
+      Example:
+
+      If a value of `KEY1 true KEY2 false` is passed to this input,
+      then it will be passed to the `adb` command like so:
+
+      ```shell
+      adb shell am instrument -e "KEY1" "true" "KEY2" "false" [...]
+      ```
+
+      See the [`adb` documentation](https://developer.android.com/studio/command-line/adb#am) for more info.
+    summary: A space-delimited list of additional options to pass to the test runner
+    title: Additional testing options

--- a/steps/android-instrumented-test/step-info.yml
+++ b/steps/android-instrumented-test/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/android-instrumented-test/step-info.yml
+++ b/steps/android-instrumented-test/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3526)

https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/releases/0.1.0

Updates based on feedback from @lpusok and @koral-- in a previous PR (https://github.com/bitrise-io/bitrise-steplib/pull/3522)

Note: I'm still waiting on an updated icon from the design team, so I will add that here in a later PR.

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.