### PR TITLE
[STEP-1998] Deprecate bitrise-add-trace-sdk Step

### DIFF
--- a/steps/add-trace-sdk/step-info.yml
+++ b/steps/add-trace-sdk/step-info.yml
@@ -1,1 +1,4 @@
 maintainer: bitrise
+removal_date: "2022-08-26"
+deprecate_notes: |
+  This step is deprecated as it is not supported anymore.


### PR DESCRIPTION
### Description

This PR deprecates the bitrise-add-trace-sdk as it is not supported anymore