### PR TITLE
nvm 1.3.1

### DIFF
--- a/steps/nvm/1.3.1/step.yml
+++ b/steps/nvm/1.3.1/step.yml
@@ -1,0 +1,60 @@
+title: Node Version Manager (NVM)
+summary: Install NVM and select Node version
+description: |
+  This step will install a specific node.js version using NVM, and will make it available for all your other steps.
+
+  NVM (Node Version Manager) is a simple bash script to manage multiple active node.js versions.
+  See [here](https://github.com/nvm-sh/nvm) for more details.
+website: https://github.com/almouro/bitrise-nvm-step
+source_code_url: https://github.com/almouro/bitrise-nvm-step
+support_url: https://github.com/almouro/bitrise-nvm-step/issues
+published_at: 2022-07-19T13:45:10.793305+02:00
+source:
+  git: https://github.com/almouro/bitrise-nvm-step.git
+  commit: 9a0b511b31af38c0b9eb76a4b140c611eae05458
+host_os_tags:
+- osx
+- ubuntu
+type_tags:
+- utility
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+inputs:
+- opts:
+    description: |
+      Working directory of the step.
+      You can leave it empty to not change it.
+    title: Working directory
+  working_dir: $BITRISE_SOURCE_DIR
+- nvm_version: 0.39.1
+  opts:
+    description: |
+      NVM version to be installed
+    is_expand: true
+    is_required: true
+    title: NVM Version
+- node_version: null
+  opts:
+    description: |
+      node.js version that NVM will install.
+
+      You can use a version pointer like:
+
+      - `6`
+      - `6.3`
+      - `6.3.1`
+
+      You can also use the NVM version aliases like:
+
+      - `node`: this installs the latest version of [`node`](https://nodejs.org/en/)
+
+      If no version is specified:
+
+      - if a `.nvmrc` is present, the version it specifies will be installed
+      - otherwise, the latest node version will be installed
+
+      More info on NVM aliases [here](https://github.com/nvm-sh/nvm#usage)
+    is_expand: true
+    is_required: false
+    title: Node version


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3551)

This adds `set -e` to ensure build fails if `nvm` step fails (see https://github.com/Almouro/bitrise-nvm-step/pull/15/files)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
