### PR TITLE
autify-upload 0.0.3

### DIFF
--- a/steps/autify-upload/0.0.3/step.yml
+++ b/steps/autify-upload/0.0.3/step.yml
@@ -1,0 +1,65 @@
+title: |
+  Autify Upload
+summary: |
+  Uploads your build to Autify.
+description: |-
+  Uploads you build `.app` to [Autify](https://autify.com/mobile) using [Autify's API](https://mobile-app.autify.com/api/docs/index.html). You can upload the iOS build with the Step.
+
+  This Step, however, does NOT generate your build: to create a `.app` file, you need the right step. For example, `Xcode build for simulator` Step or any other Step can generate a build
+website: https://github.com/autifyhq/bitrise-step-autify-upload
+source_code_url: https://github.com/autifyhq/bitrise-step-autify-upload
+support_url: https://github.com/autifyhq/bitrise-step-autify-upload/issues
+published_at: 2022-08-10T09:28:51.758942+09:00
+source:
+  git: https://github.com/autifyhq/bitrise-step-autify-upload.git
+  commit: f5c883060a80a678520020d2f6797e8ec35010cc
+project_type_tags:
+- ios
+- xamarin
+- react-native
+- cordova
+- ionic
+- flutter
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- app_dir_path: $BITRISE_APP_DIR_PATH
+  opts:
+    description: |-
+      A `.app` path.
+
+      This path is generated in the previous step. For example:
+
+      - The `Xcode build for simulator` Step generate a app directory as `$BITRISE_APP_DIR_PATH`
+    is_required: true
+    summary: null
+    title: App directory path
+- opts:
+    description: |-
+      The Project ID can be found in the Auitify URL. For example:
+
+      - `autify.com/projects/{Project ID}`
+    is_required: true
+    summary: null
+    title: Autify project id
+  project_id: null
+- opts:
+    description: You can generate a Personal Access Token from Autify's Settings page.
+      Note that this value is associated with a specific user, as the name implies.
+    is_required: true
+    is_sensitive: true
+    summary: null
+    title: Autify Personal Access Token
+  upload_token: null
+outputs:
+- AUTIFY_UPLOAD_STEP_RESULT_JSON: null
+  opts:
+    description: This is the response to the API used to upload the build
+    summary: Response when uploading the build
+    title: Autify Upload Step Result JSON


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3577)

I just fixed the docs style because the old style is serialized automatically

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
