### PR TITLE
Create step-info.yml

### DIFF
--- a/steps/snyk/step-info.yml
+++ b/steps/snyk/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.
