### PR TITLE
rustup-install 0.1.1

### DIFF
--- a/steps/rustup-install/0.1.1/step.yml
+++ b/steps/rustup-install/0.1.1/step.yml
@@ -1,0 +1,77 @@
+title: Rust Install
+summary: |
+  Install the Rust Toolchain.
+description: |
+  Install the required components to build and run Rust projects in the current workflow.
+website: https://github.com/nick0602/bitrise-step-rustup/
+source_code_url: https://github.com/nick0602/bitrise-step-rustup/
+support_url: https://github.com/nick0602/bitrise-step-rustup/issues
+published_at: 2022-09-08T23:20:56.532577496+02:00
+source:
+  git: https://github.com/nick0602/bitrise-step-rustup.git
+  commit: efef8905b38b07c112da860497b21980ad4d4039
+type_tags:
+- installer
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- opts:
+    description: |
+      If `true`, forces the use of the nightly version of the toolchain.
+    is_expand: true
+    summary: Installs and uses a nightly version of the toolchain
+    title: Use Rustup Nightly
+    value_options:
+    - "true"
+    - "false"
+  use_rustup_nightly: "false"
+- auto_update_toolchain: "false"
+  opts:
+    description: |
+      If `true`, forces the update of the Rust Toolchain.
+    is_expand: true
+    summary: Automatically update the Rust Toolchain on every run.
+    title: Update the Rust Toolchain
+    value_options:
+    - "true"
+    - "false"
+- cache_level: none
+  opts:
+    description: |
+      `all` will cache cargo binaries and rustup root folder, `none` won't cache any of the above.
+    is_expand: true
+    summary: Sets the local folders to be cached.
+    title: Set cache level
+    value_options:
+    - all
+    - none
+- opts:
+    description: |
+      If `true`, prints the exported `$RUSTUP_VERSION`, `$RUSTC_VERSION` and `$CARGO_VERSION` at the end of the step.
+    is_expand: true
+    summary: Shows the version of the Toolchain components at the end of the step.
+    title: Show Toolchain versions
+    value_options:
+    - "true"
+    - "false"
+  show_exported_envs: "false"
+outputs:
+- RUSTUP_VERSION: null
+  opts:
+    description: |
+      The version returned by the `rustup -V` command.
+    summary: The current Rust Toolchain version
+    title: Current `rustup` version
+- RUSTC_VERSION: null
+  opts:
+    description: |
+      The version returned by the `rustc -V` command.
+    summary: The current Rustc version
+    title: Current `rustc` version
+- CARGO_VERSION: null
+  opts:
+    description: |
+      The version returned by the `cargo -V` command.
+    summary: The current Cargo version
+    title: Current `cargo` version


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3609)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

---
No yml changes from [0.1.0](https://github.com/bitrise-io/bitrise-steplib/pull/3572), just a fix for Xcode stacks.