### PR TITLE
save-cache 1.0.0

### DIFF
--- a/steps/save-cache/1.0.0/step.yml
+++ b/steps/save-cache/1.0.0/step.yml
@@ -1,0 +1,98 @@
+title: Save Cache (Beta)
+summary: Saves build cache using a cache key. This Step needs to be used in combination
+  with **Restore Cache**.
+description: |
+  Saves build cache using a cache key. This Step needs to be used in combination with **Restore Cache**.
+
+  #### About key-based caching
+
+  Key-based caching is a concept where cache archives are saved and restored using a unique cache key. One Bitrise project can have multiple cache archives stored simultaneously, and the **Restore Cache Step** downloads a cache archive associated with the key provided as a Step input. The **Save Cache** Step is responsible for uploading the cache archive with an exact key.
+
+  Caches can become outdated across builds when something changes in the project (for example, a dependency gets upgraded to a new version). In this case, a new (unique) cache key is needed to save the new cache contents. This is possible if the cache key is dynamic and changes based on the project state (for example, a checksum of the dependency lockfile is part of the cache key). If you use the same dynamic cache key when restoring the cache, the Step will download the most relevant cache archive available.
+
+  Key-based caching is platform-agnostic and can be used to cache anything by carefully selecting the cache key and the files/folders to include in the cache.
+
+  #### Templates
+
+  The Step requires a string key to use when uploading a cache archive. In order to always download the most relevant cache archive for each build, the cache key input can contain template elements. The **Restore cache Step** evaluates the key template at runtime and the final key value can change based on the build environment or files in the repo. Similarly, the **Save cache** Step also uses templates to compute a unique cache key when uploading a cache archive.
+
+  The following variables are supported in the **Cache key** input:
+
+  - `cache-key-{{ .Branch }}`: Current git branch the build runs on
+  - `cache-key-{{ .CommitHash }}`: SHA-256 hash of the git commit the build runs on
+  - `cache-key-{{ .Workflow }}`: Current Bitrise workflow name (eg. `primary`)
+  - `{{ .Arch }}-cache-key`: Current CPU architecture (`amd64` or `arm64`)
+  - `{{ .OS }}-cache-key`: Current operating system (`linux` or `darwin`)
+
+  Functions available in a template:
+
+  `checksum`: This function takes one or more file paths and computes the SHA256 [checksum](https://en.wikipedia.org/wiki/Checksum) of the file contents. This is useful for creating unique cache keys based on files that describe content to cache.
+
+  Examples of using `checksum`:
+  - `cache-key-{{ checksum "package-lock.json" }}`
+  - `cache-key-{{ checksum "**/Package.resolved" }}`
+  - `cache-key-{{ checksum "**/*.gradle*" "gradle.properties" }}`
+
+  `getenv`: This function returns the value of an environment variable or an empty string if the variable is not defined.
+
+  Examples of `getenv`:
+  - `cache-key-{{ getenv "PR" }}`
+  - `cache-key-{{ getenv "BITRISEIO_PIPELINE_ID" }}`
+
+  #### Key matching
+
+  The most straightforward use case is when both the **Save cache** and **Restore cache** Steps use the same exact key to transfer cache between builds. Stored cache archives are scoped to the Bitrise project. Builds can restore caches saved by any previous Workflow run on any Bitrise Stack.
+
+  Unlike this Step, the **Restore cache** Step can define multiple keys as fallbacks when there is no match for the first cache key. See the docs of the **Restore cache** Step for more details.
+
+  #### Related steps
+
+  [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-save-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-save-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-save-cache/issues
+published_at: 2022-09-14T17:12:19.39975+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-save-cache.git
+  commit: 7f51168e673fe0794d84977dfdec1664cc49f8e1
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-save-cache
+deps:
+  brew:
+  - name: zstd
+  apt_get:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- key: null
+  opts:
+    description: |-
+      Key used for saving a cache archive.
+
+      The key supports template elements for creating dynamic cache keys. These dynamic keys change the final key value based on the build environment or files in the repo in order to create new cache archives. See the Step description for more details and examples.
+
+      The maximum length of a key is 512 characters (longer keys get truncated). Commas (`,`) are not allowed in keys.
+    is_required: true
+    summary: Key used for saving a cache archive. This can contain template elements.
+    title: Cache key
+- opts:
+    description: |-
+      List of files and folders to include in the cache.
+
+      The path can contain wildcards (`*` and `**`) that are evaluated at runtime.
+    is_required: true
+    summary: List of files and folders to include in the cache.
+    title: Paths to cache
+  paths: null
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"

--- a/steps/save-cache/step-info.yml
+++ b/steps/save-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/save-cache/step-info.yml
+++ b/steps/save-cache/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3613)

https://github.com/bitrise-steplib/bitrise-step-save-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.