### PR TITLE
jira-issue-update-build 0.2.4

### DIFF
--- a/steps/jira-issue-update-build/0.2.4/step.yml
+++ b/steps/jira-issue-update-build/0.2.4/step.yml
@@ -1,0 +1,89 @@
+title: Update JIRA issues with build number
+summary: Update fields of JIRA issues with build number.
+description: "Update fields of JIRA issues associated with current MR/PR, with the
+  current build number.\n\n### How does it work?\n\nFirst, the step needs to know
+  tasks associated with the build, so it examines Git history of the merge that it
+  was triggered by. \nEach merge request can have multiple tasks related to it. So
+  step extracts all the messages of commits involved from the merge commit, \nand
+  it looks for task keys using a predefined format (for example, [ABCD-1234]). Then
+  using JIRA API, it updates custom fields of these tasks with current build number.
+  \n\nAdditionally step can keep ticket history from failed/aborted builds. It uses
+  Bitrise API to gather information about the commits \nfrom all aborted or failed
+  builds preceding the current one.\n\n### Useful links\n- [About this step](https://www.holdapp.com/blog/bitrise-tests-made-easier-with-jira-build-step)"
+website: https://github.com/Holdapp/bitrise-step-jira-build
+source_code_url: https://github.com/Holdapp/bitrise-step-jira-build
+support_url: https://github.com/Holdapp/bitrise-step-jira-build/issues
+published_at: 2022-10-19T11:57:38.49501+02:00
+source:
+  git: https://github.com/Holdapp/bitrise-step-jira-build.git
+  commit: 051233c08277085b6047c96e46a8d87609d2e3be
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- notification
+deps:
+  brew:
+  - name: pkg-config
+  - name: go
+  apt_get:
+  - name: pkg-config
+  - name: golang
+    bin_name: go
+is_always_run: false
+is_skippable: true
+inputs:
+- app_version: null
+  opts:
+    description: "If you develop an iOS project, you can extract the version number
+      from Info.plist of the main target. It’s called `CFBundleShortVersionString`.
+      \nAlternatively, you may use a custom step that can do it for you: [bitrise-step-xcode-build-version](https://github.com/nodes-ios/bitrise-step-xcode-build-version)"
+    is_required: true
+    summary: App version (for example 1.0.0)
+    title: App version
+- jira_host: null
+  opts:
+    is_required: true
+    summary: Your JIRA instance URL (e.g. https://company.atlassian.net)
+    title: JIRA host
+- jira_custom_field_id: null
+  opts:
+    description: "You can read how to find it [here](https://confluence.atlassian.com/jirakb/how-to-find-id-for-custom-field-s-744522503.html).
+      \nAnd if you don’t have a custom field yet, check out this [guide](https://confluence.atlassian.com/adminjiraserver/adding-a-custom-field-938847222.html)
+      that explains how to create it."
+    is_required: true
+    summary: Custom field id for the build number (integer)
+    title: JIRA Custom Field ID
+- jira_username: null
+  opts:
+    is_required: true
+    summary: User (or bot) username
+    title: JIRA username
+- jira_access_token: null
+  opts:
+    is_required: true
+    is_sensitive: true
+    summary: User (or bot) password or API token (you can generate it [here](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)).
+    title: JIRA access token
+- jira_issue_pattern: ([A-Z]{1,10}-[0-9]+)
+  opts:
+    is_required: true
+    summary: A regular expression for matching issue keys in commit messages. For
+      example, ([A-Z]{1,10}-[0-9]+)
+    title: Regex pattern used to identify issue keys from commit messages
+- bitrise_api_token: null
+  opts:
+    is_required: false
+    is_sensitive: true
+    summary: Access token for bitrise.io API, you can find your API token [here](https://discuss.bitrise.io/t/personal-access-tokens-beta/1383)
+    title: Token for bitrise.io API
+- opts:
+    is_expand: true
+    is_required: true
+    summary: If false, existing content will be modified, by replacing any previous
+      builds with matching version
+    title: Should overwrite content of custom field
+    value_options:
+    - "true"
+    - "false"
+  overwrite_field: "true"


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)

## Notes

Step contains following input changes:
* `bitrise_api_token` is made optional

These changes are not breaking (option above was required previously), so I kept the major version.
