### PR TITLE
send-build-to-vk-teams 0.0.1

### DIFF
--- a/steps/send-build-to-vk-teams/0.0.1/step.yml
+++ b/steps/send-build-to-vk-teams/0.0.1/step.yml
@@ -1,0 +1,63 @@
+title: Send build to Vk Teams
+summary: |
+  Send a [VK Teams](https://myteam.mail.ru/) message to a channel or group.
+description: "Send a [VK Teams](https://myteam.mail.ru/) message to a channel or group.
+  You can:\n\n- Set a different text for failed and successful builds.\n- Linkify
+  channel names and usernames.\n\n### Configuring the Step\n\nTo use this Step, you
+  need to create an VK Teams bot and get his [API token](https://myteam.mail.ru/botapi/tutorial/)\n\nOnce
+  you're ready with those, come back to Bitrise and configure the Step itself.\n\n
+  \ 1. Create a [Secret Env Var](https://devcenter.bitrise.io/builds/env-vars-secret-env-vars/)
+  for your VK Teams API token.\n  2. Add the Secret to the **VK Teams API token**
+  input.\n  3. Toggle the **Run if previous Step failed** option on - you should see
+  a white checkmark on green background next to it. This allows VK Teams messages
+  to be sent for failed builds, too.\n  4. In the **Target VK Teams channel, group
+  or username**, set where the VK Teams message should be sent. \n  5. Customize your
+  messages as you'd like. For the details, see the respective inputs."
+website: https://github.com/dzemmarat/bitrise-step-send-build-to-vk-teams
+source_code_url: https://github.com/dzemmarat/bitrise-step-send-build-to-vk-teams
+support_url: https://github.com/dzemmarat/bitrise-step-send-build-to-vk-teams/issues
+published_at: 2022-10-30T22:47:58.87639716+04:00
+source:
+  git: https://github.com/dzemmarat/bitrise-step-send-build-to-vk-teams.git
+  commit: 299c7b470eb24f0514ea376dbdb73ba3fc629d44
+type_tags:
+- notification
+toolkit:
+  go:
+    package_name: github.com/dzemmarat/bitrise-step-send-build-to-vk-teams
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+inputs:
+- bot_token: $BOT_TOKEN
+  opts:
+    description: |
+      Token for your bot
+    is_required: true
+    is_sensitive: true
+    title: Bot Token
+- chat_id: $CHAT_ID
+  opts:
+    description: |
+      Id of your chat
+    is_required: true
+    is_sensitive: true
+    title: Chat id
+- commit_message: Commit message
+  opts:
+    description: |
+      Commit message
+    is_required: true
+    title: Commit message
+- commit_author: Commit author
+  opts:
+    description: |
+      Commit author
+    is_required: true
+    title: Commit author
+- file_url: File url
+  opts:
+    description: |
+      File url
+    is_required: true
+    title: File url

--- a/steps/send-build-to-vk-teams/step-info.yml
+++ b/steps/send-build-to-vk-teams/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3648)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.