### PR TITLE
restore-npm-cache 1.0.0

### DIFF
--- a/steps/restore-npm-cache/1.0.0/step.yml
+++ b/steps/restore-npm-cache/1.0.0/step.yml
@@ -1,0 +1,39 @@
+title: Restore NPM Cache (Beta)
+summary: Restores cached node_modules dependencies. This Step needs to be used in
+  combination with **Save NPM Cache**.
+description: |
+  Restores cached node_modules dependencies. This Step needs to be used in combination with **Save NPM Cache**.
+
+  This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html) and sets up the cache key and path automatically for NPM dependencies. If you'd like to change the cache keys, you might want to use the generic [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache) Step instead.
+
+  #### Related steps
+
+  [Save NPM cache](https://github.com/bitrise-steplib/bitrise-step-save-npm-cache/)
+
+  [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-restore-npm-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-restore-npm-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-restore-npm-cache/issues
+published_at: 2022-11-09T17:25:04.384187+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-restore-npm-cache.git
+  commit: 591efdaf58d6edcb9250f6aa1dcdaa1180c3b154
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-restore-npm-cache
+deps:
+  brew:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"

--- a/steps/restore-npm-cache/step-info.yml
+++ b/steps/restore-npm-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3659)

https://github.com/bitrise-steplib/bitrise-step-restore-npm-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.