### PR TITLE
save-cocoapods-cache 1.0.0

### DIFF
--- a/steps/save-cocoapods-cache/1.0.0/step.yml
+++ b/steps/save-cocoapods-cache/1.0.0/step.yml
@@ -1,0 +1,45 @@
+title: Save Cocoapods Cache (Beta)
+summary: Caches the Pods folder. This Step needs to be used in combination with **Restore
+  Cocoapods Cache**.
+description: |
+  Caches dependencies in the Pods folder. This Step needs to be used in combination with **Restore Cocoapods Cache**.
+
+  This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html) and sets up the cache key and path automatically for Cocoapods dependencies. If you'd like to change the cache key (or paths to cache), you might want to use the generic [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache) Step instead.
+
+  #### Related steps
+
+  [Restore Cocoapods cache](https://github.com/bitrise-steplib/bitrise-step-restore-cocoapods-cache/)
+
+  [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache/issues
+published_at: 2022-11-09T17:33:45.40002+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache.git
+  commit: a088bb985fe4fa9b424877e3ad8387dd52e5f630
+project_type_tags:
+- ios
+- cordova
+- ionic
+- react-native
+- flutter
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache
+deps:
+  brew:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"

--- a/steps/save-cocoapods-cache/step-info.yml
+++ b/steps/save-cocoapods-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3662)

https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.