### PR TITLE
nowsecure-severitycheck 0.0.1

### DIFF
--- a/steps/nowsecure-severitycheck/0.0.1/step.yml
+++ b/steps/nowsecure-severitycheck/0.0.1/step.yml
@@ -1,0 +1,43 @@
+title: |
+  NowSecure_SeverityCheck
+summary: |
+  Checking Severity of Critical/High/Medium issues in app bundle
+description: |
+  Step Checking the Critical/High/Medium Severity issues in app bundle and stop the build if any severity occurs.
+website: https://github.com/mhidaya90/bitrise-step-nowsecure-severitycheck
+source_code_url: https://github.com/mhidaya90/bitrise-step-nowsecure-severitycheck
+support_url: https://github.com/mhidaya90/bitrise-step-nowsecure-severitycheck
+published_at: 2023-01-06T18:12:39.82797696+05:30
+source:
+  git: https://github.com/mhidaya90/bitrise-step-nowsecure-severitycheck.git
+  commit: 850e0040dfc4310b1aeb04d0233ebd66017f1b0d
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- nowsecure_api_token: null
+  opts:
+    description: |
+      NowSecure token generated from NowSecure Platform console
+    is_required: true
+    is_sensitive: true
+    summary: Your NowSecure Platform API token
+    title: NowSecure Platform API token
+- opts:
+    description: |
+      The platform associated with application. Allowed values- "ios", "android"
+    is_required: true
+    is_sensitive: true
+    summary: The platform associated with application. Allowed values- "ios", "android"
+    title: Application Platform
+  platform: null
+- opts:
+    description: |
+      The package/bundle identifier for the application. Start with "com.cargill.******"
+    is_required: true
+    is_sensitive: true
+    summary: The package identifier for application
+    title: Application Package/Bundle Identifier
+  package: null


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
