### PR TITLE
docs: Update deprecation notice messages

### DIFF
--- a/steps/appcenter-app-release/step-info.yml
+++ b/steps/appcenter-app-release/step-info.yml
@@ -4,5 +4,5 @@ deprecate_notes: |
   This step is no longer maintained by its author.
   
   It's recommended to use the new AppCenter steps created and maintained by Bitrise:
-  - iOS: https://github.com/bitrise-steplib/steps-appcenter-deploy-ios
-  - Android: https://github.com/bitrise-steplib/steps-appcenter-deploy-android
+  - For iOS, use the [AppCenter iOS Deploy](https://github.com/bitrise-steplib/steps-appcenter-deploy-ios) Step instead
+  - For Android, use the [AppCenter Android Deploy](https://github.com/bitrise-steplib/steps-appcenter-deploy-android) Step instead

--- a/steps/create-android-emulator/step-info.yml
+++ b/steps/create-android-emulator/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, use avd-manager step instead.
+  This step is deprecated, use [AVD Manager](https://github.com/bitrise-steplib/steps-avd-manager) Step instead.
 maintainer: bitrise
 removal_date: "2019-08-25"

--- a/steps/deploy-to-itunesconnect-shenzhen/step-info.yml
+++ b/steps/deploy-to-itunesconnect-shenzhen/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, use deploy-to-itunesconnect-application-loader step instead.
+  This step is deprecated, use [Deploy to App Store Connect - Application Loader](https://github.com/bitrise-steplib/steps-deploy-to-itunesconnect-application-loader) step instead.
 maintainer: bitrise
 removal_date: "2018-09-20"

--- a/steps/firebase-testlab/step-info.yml
+++ b/steps/firebase-testlab/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, please use Virtual Device Testing for Android instead
+  This step is deprecated, please use [Virtual Device Testing for Android](https://github.com/bitrise-steplib/steps-virtual-device-testing-for-android) instead
 maintainer: bitrise
 removal_date: "2018-09-20"

--- a/steps/ios-auto-provision-appstoreconnect/step-info.yml
+++ b/steps/ios-auto-provision-appstoreconnect/step-info.yml
@@ -4,15 +4,10 @@ deprecate_notes: |
   This Step has been deprecated in favour of the new automatic code signing options on Bitrise.
 
   Option A)
-  The latest versions of the **Xcode Archive & Export for iOS**,
-  **Xcode Build for testing for iOS**,
-  and the **Export iOS and tvOS Xcode archive** Steps
-  have built-in automatic code signing.
+  The latest versions of the [Xcode Archive & Export for iOS](https://github.com/bitrise-steplib/steps-xcode-archive), [Xcode Build for testing for iOS](https://github.com/bitrise-steplib/steps-xcode-build-for-test), and the [Export iOS and tvOS Xcode archive](https://github.com/bitrise-steplib/steps-export-xcarchive) Steps have built-in automatic code signing.
   We recommend removing this Step from your Workflow and using the automatic code signing feature in the Steps mentioned above.
 
   Option B)
-  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with
-  the **Manage iOS Code signing** (https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
+  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with the [Manage iOS Code signing](https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
 
-  You can read more about these changes in our blog post:
-  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise
+  You can [read more](https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise) about these changes in our blog post.

--- a/steps/ios-auto-provision/step-info.yml
+++ b/steps/ios-auto-provision/step-info.yml
@@ -4,15 +4,11 @@ deprecate_notes: |
   This Step has been deprecated in favour of the new automatic code signing options on Bitrise.
 
   Option A)
-  The latest versions of the **Xcode Archive & Export for iOS**,
-  **Xcode Build for testing for iOS**,
-  and the **Export iOS and tvOS Xcode archive** Steps
-  have built-in automatic code signing.
+  The latest versions of the [Xcode Archive & Export for iOS](https://github.com/bitrise-steplib/steps-xcode-archive), [Xcode Build for testing for iOS](https://github.com/bitrise-steplib/steps-xcode-build-for-test), and the [Export iOS and tvOS Xcode archive](https://github.com/bitrise-steplib/steps-export-xcarchive) Steps have built-in automatic code signing.
   We recommend removing this Step from your Workflow and using the automatic code signing feature in the Steps mentioned above.
 
   Option B)
-  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with
-  the **Manage iOS Code signing** (https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
+  If you are not using any of the mentioned Xcode steps, then you can replace this iOS Auto Provision Step with the [Manage iOS Code signing](https://www.bitrise.io/integrations/steps/manage-ios-code-signing) Step.
 
-  You can read more about these changes in our blog post:
-  https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise
+  You can [read more](https://blog.bitrise.io/post/simplifying-automatic-code-signing-on-bitrise) about these changes in our blog post.
+

--- a/steps/nuget-restore/step-info.yml
+++ b/steps/nuget-restore/step-info.yml
@@ -1,5 +1,5 @@
 deprecate_notes: |
   The Xamarin development platform is not officially supported.
-  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
+  [More info](https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise)
 maintainer: bitrise
 removal_date: "2022-01-31"

--- a/steps/start-android-emulator/step-info.yml
+++ b/steps/start-android-emulator/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, use avd-manager step instead.
+  This step is deprecated, use [AVD Manager](https://github.com/bitrise-steplib/steps-avd-manager) Step instead.
 maintainer: bitrise
 removal_date: "2019-08-25"

--- a/steps/xamarin-android-test/step-info.yml
+++ b/steps/xamarin-android-test/step-info.yml
@@ -1,5 +1,5 @@
 deprecate_notes: |
   The Xamarin development platform is not officially supported.
-  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
+  [More info](https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise)
 maintainer: bitrise
 removal_date: "2022-01-31"

--- a/steps/xamarin-archive/step-info.yml
+++ b/steps/xamarin-archive/step-info.yml
@@ -1,5 +1,5 @@
 deprecate_notes: |
   The Xamarin development platform is not officially supported.
-  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise
+  [More info](https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise)
 maintainer: bitrise
 removal_date: "2022-01-31"

--- a/steps/xamarin-components-restore/step-info.yml
+++ b/steps/xamarin-components-restore/step-info.yml
@@ -1,5 +1,5 @@
 deprecate_notes: |
   The Xamarin development platform is not officially supported.
-  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise 
+  [More info](https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise)
 maintainer: bitrise
 removal_date: "2022-01-31"

--- a/steps/xamarin-ios-test/step-info.yml
+++ b/steps/xamarin-ios-test/step-info.yml
@@ -1,5 +1,5 @@
 deprecate_notes: |
   The Xamarin development platform is not officially supported.
-  More info: https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise 
+  [More info](https://blog.bitrise.io/post/xamarin-support-ends-in-2022-on-bitrise)
 maintainer: bitrise
 removal_date: "2022-01-31"

--- a/steps/xamarin-test-cloud-for-android/step-info.yml
+++ b/steps/xamarin-test-cloud-for-android/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, please use App Center upload and schedule tests instead
+  This step is deprecated, please use [App Center upload and schedule tests](https://github.com/bitrise-steplib/steps-appcenter-test) Step instead.
 maintainer: bitrise
 removal_date: "2018-10-26"

--- a/steps/xamarin-test-cloud-for-calabash-android/step-info.yml
+++ b/steps/xamarin-test-cloud-for-calabash-android/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, please use App Center upload and schedule tests instead
+  This step is deprecated, please use [App Center upload and schedule tests](https://github.com/bitrise-steplib/steps-appcenter-test) Step instead.
 maintainer: bitrise
 removal_date: "2018-10-26"

--- a/steps/xamarin-test-cloud-for-calabash-ios/step-info.yml
+++ b/steps/xamarin-test-cloud-for-calabash-ios/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, please use App Center upload and schedule tests instead
+  This step is deprecated, please use [App Center upload and schedule tests](https://github.com/bitrise-steplib/steps-appcenter-test) Step instead.
 maintainer: bitrise
 removal_date: "2018-10-26"

--- a/steps/xamarin-test-cloud-for-ios/step-info.yml
+++ b/steps/xamarin-test-cloud-for-ios/step-info.yml
@@ -1,4 +1,4 @@
 deprecate_notes: |
-  This step is deprecated, please use App Center upload and schedule tests instead
+  This step is deprecated, please use [App Center upload and schedule tests](https://github.com/bitrise-steplib/steps-appcenter-test) Step instead.
 maintainer: bitrise
 removal_date: "2018-10-26"

--- a/steps/xamarin-user-management/step-info.yml
+++ b/steps/xamarin-user-management/step-info.yml
@@ -1,4 +1,4 @@
-deprecate_notes: This step is deprecated, [The Component Store has been discontinued](https://docs.microsoft.com/en-us/xamarin/cross-platform/troubleshooting/component-nuget?tabs=vswin)
+deprecate_notes: This step is deprecated, [The Component Store](https://docs.microsoft.com/en-us/xamarin/cross-platform/troubleshooting/component-nuget?tabs=vswin) has been discontinued
   as of May 15, 2018.
 maintainer: bitrise
 removal_date: "2019-01-06"


### PR DESCRIPTION
The messages were updated to contain Markdown links. Where it was applicable, I created links for the referenced steps.