### PR TITLE
Restore dart cache 1.0.0

### DIFF
--- a/steps/restore-carthage-cache/1.0.0/step.yml
+++ b/steps/restore-carthage-cache/1.0.0/step.yml
@@ -1,0 +1,60 @@
+title: Restore Carthage Cache
+summary: Restores cached Carthage dependencies. This Step needs to be used in combination
+  with **Save Carthage Cache**.
+description: |
+  Restores cached Carthage prebuilt frameworks. This Step needs to be used in combination with **Save Carthage Cache**.
+
+  This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html) and sets up the cache key and path automatically for Carthage dependencies. If you'd like to change the cache keys, you might want to use the generic [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache) Step instead.
+
+  #### Related steps
+
+  [Save Carthage cache](https://github.com/bitrise-steplib/bitrise-step-save-carthage-cache/)
+
+  [Save Cocoapods cache](https://github.com/bitrise-steplib/bitrise-step-save-cocoapods-cache/)
+
+  [Save SPM cache](https://github.com/bitrise-steplib/bitrise-step-save-spm-cache/)
+
+  [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-restore-carthage-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-restore-carthage-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-restore-carthage-cache/issues
+published_at: 2023-02-10T10:03:24.688459+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-restore-carthage-cache.git
+  commit: 60f64657a0c7a98530b2e7a7f1d8e2c6464fd9bc
+project_type_tags:
+- ios
+- cordova
+- ionic
+- react-native
+- flutter
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-restore-carthage-cache
+deps:
+  brew:
+  - name: zstd
+  apt_get:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"
+outputs:
+- BITRISE_CACHE_HIT: null
+  opts:
+    description: |-
+      Indicates if a cache entry was restored. Possible values:
+      - `exact`: Exact cache hit for the first requested cache key
+      - `partial`: Cache hit for a key other than the first
+      - `false` No cache hit, nothing was restored
+    title: Cache hit

--- a/steps/restore-carthage-cache/step-info.yml
+++ b/steps/restore-carthage-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/restore-dart-cache/1.0.0/step.yml
+++ b/steps/restore-dart-cache/1.0.0/step.yml
@@ -1,0 +1,49 @@
+title: Restore Dart Cache
+summary: Restores Dart (Flutter) dependencies. This Step needs to be used in combination
+  with **Save Dart Cache**.
+description: |
+  Restores Dart (Flutter) dependencies. This Step needs to be used in combination with **Save Dart Cache**.
+
+  This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html) and sets up the cache key and path automatically for Dart dependencies. If you'd like to change the cache keys, you might want to use the generic [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache) Step instead.
+
+  #### Related steps
+
+  [Save Dart cache](https://github.com/bitrise-steplib/bitrise-step-save-dart-cache/)
+
+  [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-restore-dart-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-restore-dart-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-restore-dart-cache/issues
+published_at: 2023-02-10T10:05:48.139044+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-restore-dart-cache.git
+  commit: 6fa41b4a4723db98e052b25ec26754bf7a541af4
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-restore-dart-cache
+deps:
+  brew:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"
+outputs:
+- BITRISE_CACHE_HIT: null
+  opts:
+    description: |-
+      Indicates if a cache entry was restored. Possible values:
+
+      - `exact`: Exact cache hit for the first requested cache key
+      - `partial`: Cache hit for a key other than the first
+      - `false` No cache hit, nothing was restored
+    title: Cache hit

--- a/steps/restore-dart-cache/step-info.yml
+++ b/steps/restore-dart-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/save-dart-cache/1.0.0/step.yml
+++ b/steps/save-dart-cache/1.0.0/step.yml
@@ -1,0 +1,41 @@
+title: Save Dart Cache
+summary: Saves Dart (Flutter) dependencies. This Step needs to be used in combination
+  with **Restore Dart Cache**.
+description: |
+  Saves Dart (Flutter) dependencies. This Step needs to be used in combination with **Restore Dart Cache**.
+
+  This Step is based on [key-based caching](https://devcenter.bitrise.io/en/builds/caching/key-based-caching.html) and sets up the cache key and path automatically for Dart dependencies. If you'd like to change the cache key (or paths to cache), you might want to use the generic [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache) Step instead.
+
+  #### Related steps
+
+  [Restore Dart cache](https://github.com/bitrise-steplib/bitrise-step-restore-dart-cache/)
+
+  [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-save-dart-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-save-dart-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-save-dart-cache/issues
+published_at: 2023-02-10T10:04:50.104363+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-save-dart-cache.git
+  commit: 4ae384577f0957fa733469a5813886283fd0c9c6
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-save-dart-cache
+deps:
+  brew:
+  - name: zstd
+  apt_get:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"

--- a/steps/save-dart-cache/step-info.yml
+++ b/steps/save-dart-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://bitrise-steplib-git-check.herokuapp.com/tag?pr=3744)

https://github.com/bitrise-steplib/bitrise-step-restore-carthage-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.