### PR TITLE
appdome-build-2secure-android 1.0.0

### DIFF
--- a/steps/appdome-build-2secure-android/1.0.0/step.yml
+++ b/steps/appdome-build-2secure-android/1.0.0/step.yml
@@ -1,0 +1,48 @@
+title: Appdome Build
+summary: |
+  Builds a mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, bulding and signing mobile apps using Appdome's API.
+website: https://github.com/Appdome/bitrise_build-2secure-android
+source_code_url: https://github.com/Appdome/bitrise_build-2secure-android
+support_url: https://github.com/Appdome/bitrise_build-2secure-ios/issues
+published_at: 2023-03-30T16:12:33.787476+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git
+  commit: 279af4be545d98796961ae0760a0353f2e395aba
+project_type_tags:
+- android
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- app_location: $APP_LOCATION
+  opts:
+    is_required: true
+    summary: URL to app file
+    title: App file URL
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- app_signing_cert: null
+  opts:
+    description: Google Play signing SHA-1/SHA256 fingerprint (will be used if provided)
+    is_required: false
+    title: GooglePlay Signing Fingerprint

--- a/steps/appdome-build-2secure-android/step-info.yml
+++ b/steps/appdome-build-2secure-android/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3787)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.