### PR TITLE
Bitrise step appdome build 2secure android 1.0.2

### DIFF
--- a/steps/bitrise-step-appdome-build-2secure-android/1.0.2/step.yml
+++ b/steps/bitrise-step-appdome-build-2secure-android/1.0.2/step.yml
@@ -2,7 +2,7 @@ title: Appdome-Build-2Secure step for Android
 summary: |
   Builds a mobile app using Appdome's platform
 description: |
-  Integration that allows activating security and app protection features, bulding and signing mobile apps using Appdome's API. For detailes see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+  Integration that allows activating security and app protection features, bulding and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
 website: https://github.com/Appdome/bitrise_build-2secure-android
 source_code_url: https://github.com/Appdome/bitrise_build-2secure-android
 support_url: https://github.com/Appdome/bitrise_build-2secure-android/issues

--- a/steps/bitrise-step-appdome-build-2secure-android/1.0.2/step.yml
+++ b/steps/bitrise-step-appdome-build-2secure-android/1.0.2/step.yml
@@ -1,0 +1,52 @@
+title: Appdome-Build-2Secure step for Android
+summary: |
+  Builds a mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, bulding and signing mobile apps using Appdome's API. For detailes see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise_build-2secure-android
+source_code_url: https://github.com/Appdome/bitrise_build-2secure-android
+support_url: https://github.com/Appdome/bitrise_build-2secure-android/issues
+published_at: 2023-04-23T11:02:49.138915+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git
+  commit: 09b86c4ddacf9efe6200e2b46fccd34d9ec9d058
+project_type_tags:
+- android
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- app_location: null
+  opts:
+    is_required: true
+    summary: URL to app file
+    title: App file URL
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- gp_signing: "true"
+  opts:
+    description: Sign the app for Google Play? If 'true', requires $SIGN_FINGERPRINT
+      in the Secrets tab.
+    is_required: true
+    title: Google Play Signing?
+    value_options:
+    - "true"
+    - "false"

--- a/steps/bitrise-step-appdome-build-2secure-android/step-info.yml
+++ b/steps/bitrise-step-appdome-build-2secure-android/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/bitrise-step-appdome-build-2secure-ios/1.0.2/step.yml
+++ b/steps/bitrise-step-appdome-build-2secure-ios/1.0.2/step.yml
@@ -1,0 +1,48 @@
+title: Appdome-Build-2Secure step for iOS
+summary: |
+  Builds an iOS mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, bulding and signing mobile apps using Appdome's API. For detailes see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise_build-2secure-ios
+source_code_url: https://github.com/Appdome/bitrise_build-2secure-ios
+support_url: https://github.com/Appdome/bitrise_build-2secure-ios/issues
+published_at: 2023-04-23T10:59:00.488173+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
+  commit: 8c31b1530cc5ee7c7bfe5e6e50918a1bd38d4a61
+project_type_tags:
+- ios
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- app_location: $BITRISE_IPA_PATH
+  opts:
+    is_required: true
+    summary: URL to app file
+    title: App file URL
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- entitlements: null
+  opts:
+    description: iOS Entitlement EnvVar/s (separated by space)
+    is_required: true
+    title: iOS Entitlement EnvVar/s

--- a/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
+++ b/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3809)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.