### PR TITLE
activate-build-cache-for-gradle 1.0.0

### DIFF
--- a/steps/activate-build-cache-for-gradle/1.0.0/step.yml
+++ b/steps/activate-build-cache-for-gradle/1.0.0/step.yml
@@ -1,0 +1,55 @@
+title: Activate Bitrise Build Cache for Gradle
+summary: Activates Bitrise Remote Build Cache for subsequent Gradle builds in the
+  workflow
+description: |
+  This Step activates Bitrise's remote build cache for subsequent Gradle executions in the workflow.
+
+  After this Step executes, Gradle builds will automatically read from the remote cache and push new entries if it's enabled.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache
+published_at: 2023-04-24T15:17:29.28468+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache.git
+  commit: 8d9cd958ca84ad07975b29604b77b919175d7e42
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Whether the build can not only read, but write new entries to the remote
+      cache
+    title: Push new cache entries
+    value_options:
+    - "true"
+    - "false"
+  push: "true"
+- opts:
+    description: |-
+      Level of cache entry validation for both uploads and downloads.
+
+      Levels:
+      - `none`: no validation.
+      - `warning`: print a warning about invalid cache entries, but don't interrupt the build
+      - `error`: print an error about invalid cache entries and interrupt the build
+    is_required: true
+    summary: Level of cache entry validation for both uploads and downloads.
+    title: Validation level
+    value_options:
+    - none
+    - warning
+    - error
+  validation_level: warning
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"

--- a/steps/activate-build-cache-for-gradle/step-info.yml
+++ b/steps/activate-build-cache-for-gradle/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/activate-build-cache-for-gradle/step-info.yml
+++ b/steps/activate-build-cache-for-gradle/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3812)

https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.