### PR TITLE
Verify Appdome

### DIFF
--- a/steps/appdome-build-2secure-android/step-info.yml
+++ b/steps/appdome-build-2secure-android/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: verified

--- a/steps/appdome-build-2secure-ios/step-info.yml
+++ b/steps/appdome-build-2secure-ios/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: verified


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.
