### PR TITLE
Appdome build 2secure android 1.0.10

### DIFF
--- a/steps/appdome-build-2secure-android/1.0.10/step.yml
+++ b/steps/appdome-build-2secure-android/1.0.10/step.yml
@@ -1,0 +1,89 @@
+title: Appdome-Build-2Secure for Android
+summary: |
+  Builds a mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, building and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android/issues
+published_at: 2023-06-18T17:06:39.553506+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git
+  commit: ab74ba35600f7f766f6ccdd97ae34a6c9b2e9943
+project_type_tags:
+- android
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+inputs:
+- app_location: null
+  opts:
+    is_required: true
+    summary: URL to app file (apk/aab) or an EnvVar representing its path (i.e. $BITRISE_APK_PATH
+      or $BITRISE_AAB_PATH)
+    title: App file URL or EnvVar
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- gp_signing: "false"
+  opts:
+    description: Sign the app for Google Play? If 'true', requires $SIGN_FINGERPRINT
+      in the Secrets tab.
+    is_required: true
+    title: Google Play Signing?
+    value_options:
+    - "true"
+    - "false"
+- build_logs: "false"
+  opts:
+    description: Build with diagnostic logs?
+    is_required: true
+    title: Build with logs?
+    value_options:
+    - "true"
+    - "false"
+outputs:
+- APPDOME_SECURED_APK_PATH: null
+  opts:
+    description: |
+      Local path of the secured .apk file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .apk file
+    title: Secured .apk file path
+- APPDOME_SECURED_AAB_PATH: null
+  opts:
+    description: |
+      Local path of the secured .aab file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .aab file
+    title: Secured .aab file path
+- APPDOME_PRIVATE_SIGN_SCRIPT_PATH: null
+  opts:
+    description: |
+      Local path of the .sh sign script file. Available when 'Signing Method' set to 'Auto-Dev-Signing'
+    summary: Local path of the .sh sign script file
+    title: .sh sign script file path
+- APPDOME_CERTIFICATE_PATH: null
+  opts:
+    summary: Local path of the Certified Secure Certificate .pdf file
+    title: Certified Secure Certificate .pdf file path

--- a/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
+++ b/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
@@ -1,4 +1,4 @@
 maintainer: community
 removal_date: "2023-06-11"
 deprecate_notes: |
-  This step is deprecated as it was replaced by bitrise-appdome-build-2secure-ios, and it is no longer maintained.
+  This step is deprecated as it was replaced by appdome-build-2secure-ios, and it is no longer maintained.

--- a/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
+++ b/steps/bitrise-step-appdome-build-2secure-ios/step-info.yml
@@ -1,1 +1,4 @@
 maintainer: community
+removal_date: "2023-06-11"
+deprecate_notes: |
+  This step is deprecated as it was replaced by bitrise-appdome-build-2secure-ios, and it is no longer maintained.


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
