### PR TITLE
bitrise-step-activate-gradle-remote-cache 1.0.2

### DIFF
--- a/steps/bitrise-step-activate-gradle-remote-cache/1.0.2/step.yml
+++ b/steps/bitrise-step-activate-gradle-remote-cache/1.0.2/step.yml
@@ -1,0 +1,18 @@
+title: Activate Bitrise Build Cache for Tuist
+summary: Activates Bitrise Remote Build Cache add-on for subsequent Tuist builds in
+  the workflow
+description: |
+  This Step activates Bitrise's remote build cache add-on for subsequent Tuist executions in the workflow.
+
+  After this Step executes, Tuist builds will automatically read from the remote cache and push new entries.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+published_at: 2023-06-30T10:47:40.621182-07:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache.git
+  commit: 1ec62acc47d6aa64960797fc2cb7e4c41c70ce70
+type_tags:
+- utility
+is_skippable: true
+run_if: .IsCI

--- a/steps/bitrise-step-activate-gradle-remote-cache/step-info.yml
+++ b/steps/bitrise-step-activate-gradle-remote-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3882)

https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache/releases/1.0.2

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [*] __I will not move an already shared step version's tag to another commit__
- [*] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [*] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [*] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [*] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.