### PR TITLE
Appdome build 2secure ios 1.0.13

### DIFF
--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -1,0 +1,86 @@
+title: Appdome-Build-2Secure for iOS
+summary: |
+  Builds an iOS mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, building and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
+source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
+support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
+published_at: 2023-06-29T14:52:50.04632+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
+  commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c
+project_type_tags:
+- ios
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+inputs:
+- app_location: $BITRISE_IPA_PATH
+  opts:
+    is_required: true
+    summary: URL to app file (ipa) or an EnvVar representing its path (i.e. $BITRISE_IPA_PATH)
+    title: App file URL or EnvVar
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- opts:
+    description: Which provisioning profile file name/s from the uploaded provisioning
+      profiles to use. If not provided, all provisioning profiles uploaded to 'Code
+      Signing & Files' section will be used.
+    is_required: false
+    title: List of provisioning profile files (separated by spaces) to be used
+  provisioning_profiles: null
+- entitlements: null
+  opts:
+    description: iOS Entitlement EnvVar/s (separated by space), required for Auto-Dev-Singing
+      and On-Appdome Signing.
+    is_required: false
+    title: iOS Entitlement EnvVar/s
+- build_logs: "false"
+  opts:
+    description: Build the app with Appdome's Diagnostic Logs
+    is_required: true
+    title: Build With Diagnostic Logs
+    value_options:
+    - "true"
+    - "false"
+outputs:
+- APPDOME_SECURED_IPA_PATH: null
+  opts:
+    description: |
+      Local path of the secured .ipa file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .ipa file
+    title: Secured .ipa file path
+- APPDOME_PRIVATE_SIGN_SCRIPT_PATH: null
+  opts:
+    description: |
+      Local path of the .sh sign script file. Available when 'Signing Method' set to 'Auto-Dev-Signing'
+    summary: Local path of the .sh sign script file
+    title: .sh sign script file path
+- APPDOME_CERTIFICATE_PATH: null
+  opts:
+    summary: Local path of the Certified Secure Certificate .pdf file
+    title: Certified Secure Certificate .pdf file path

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-06-29T14:52:50.04632+03:00
+published_at: 2023-07-03T12:09:01.788676+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
   commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3887)

- add support for custom certificate file
- add support for custom provisioning files 
- add support for multiple provisioning files
- add support for spaces in provisioning files and certificate files
