### PR TITLE
Appdome build 2secure ios 1.0.13

### DIFF
--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-04T10:19:33.79057+03:00
+published_at: 2023-07-04T15:20:53.571372+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
-  commit: b1fec9cd1149a0a2d984acbd64e665744237283d
+  commit: 52f3351a6c86ccd79d9fc59f0a2d60730df7fa3d
 project_type_tags:
 - ios
 type_tags:

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-03T16:12:39.416677+03:00
+published_at: 2023-07-03T16:23:22.879842+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
-  commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c
+  commit: 57be09e81f55963bae0557e1af42512a34374b2b
 project_type_tags:
 - ios
 type_tags:
@@ -46,12 +46,23 @@ inputs:
     - Private-Signing
     - Auto-Dev-Signing
   sign_method: On-Appdome
-- opts:
-    description: Which provisioning profile file name/s from the uploaded provisioning
-      profiles to use. If not provided, all provisioning profiles uploaded to 'Code
-      Signing & Files' section will be used.
+- certificate_file: null
+  opts:
+    description: Code signing cetificate file name (from the uploaded code signing
+      certificates) to use. If not provided, the LAST certificate among the uploaded
+      files to 'Code Signing & Files' section will be used. If you don't know the
+      file name of the certificate you want to use, download the certificate from
+      the Code Signing & Files section to your computer and type here its file name
+      and extension as was downloaded. Only ONE certificate file is supported.
     is_required: false
-    title: List of provisioning profile files (separated by spaces) to be used
+    title: Code signing cetificates (p.12) file name
+- opts:
+    description: List of provisioning profile file name/s (with no file extension,
+      separated by commas) from the uploaded provisioning profiles to use. If not
+      provided, all provisioning profiles uploaded to 'Code Signing & Files' section
+      will be used.
+    is_required: false
+    title: Provisioning profile file name/s
   provisioning_profiles: null
 - entitlements: null
   opts:

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-03T12:09:01.788676+03:00
+published_at: 2023-07-03T16:12:39.416677+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
   commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-03T16:23:22.879842+03:00
+published_at: 2023-07-04T09:58:59.943474+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
   commit: 57be09e81f55963bae0557e1af42512a34374b2b

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -1,0 +1,86 @@
+title: Appdome-Build-2Secure for iOS
+summary: |
+  Builds an iOS mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, building and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
+source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
+support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
+published_at: 2023-06-29T14:52:50.04632+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
+  commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c
+project_type_tags:
+- ios
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+inputs:
+- app_location: $BITRISE_IPA_PATH
+  opts:
+    is_required: true
+    summary: URL to app file (ipa) or an EnvVar representing its path (i.e. $BITRISE_IPA_PATH)
+    title: App file URL or EnvVar
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- opts:
+    description: Which provisioning profile file name/s from the uploaded provisioning
+      profiles to use. If not provided, all provisioning profiles uploaded to 'Code
+      Signing & Files' section will be used.
+    is_required: false
+    title: List of provisioning profile files (separated by spaces) to be used
+  provisioning_profiles: null
+- entitlements: null
+  opts:
+    description: iOS Entitlement EnvVar/s (separated by space), required for Auto-Dev-Singing
+      and On-Appdome Signing.
+    is_required: false
+    title: iOS Entitlement EnvVar/s
+- build_logs: "false"
+  opts:
+    description: Build the app with Appdome's Diagnostic Logs
+    is_required: true
+    title: Build With Diagnostic Logs
+    value_options:
+    - "true"
+    - "false"
+outputs:
+- APPDOME_SECURED_IPA_PATH: null
+  opts:
+    description: |
+      Local path of the secured .ipa file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .ipa file
+    title: Secured .ipa file path
+- APPDOME_PRIVATE_SIGN_SCRIPT_PATH: null
+  opts:
+    description: |
+      Local path of the .sh sign script file. Available when 'Signing Method' set to 'Auto-Dev-Signing'
+    summary: Local path of the .sh sign script file
+    title: .sh sign script file path
+- APPDOME_CERTIFICATE_PATH: null
+  opts:
+    summary: Local path of the Certified Secure Certificate .pdf file
+    title: Certified Secure Certificate .pdf file path

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-04T09:58:59.943474+03:00
+published_at: 2023-07-04T10:09:59.058884+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
   commit: 57be09e81f55963bae0557e1af42512a34374b2b

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,10 +6,10 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-07-04T10:09:59.058884+03:00
+published_at: 2023-07-04T10:19:33.79057+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
-  commit: 57be09e81f55963bae0557e1af42512a34374b2b
+  commit: b1fec9cd1149a0a2d984acbd64e665744237283d
 project_type_tags:
 - ios
 type_tags:
@@ -55,7 +55,7 @@ inputs:
       the Code Signing & Files section to your computer and type here its file name
       and extension as was downloaded. Only ONE certificate file is supported.
     is_required: false
-    title: Code signing cetificates (p.12) file name
+    title: Code signing cetificates (.p12) file name
 - opts:
     description: List of provisioning profile file name/s (with no file extension,
       separated by commas) from the uploaded provisioning profiles to use. If not

--- a/steps/appdome-build-2secure-ios/1.0.13/step.yml
+++ b/steps/appdome-build-2secure-ios/1.0.13/step.yml
@@ -6,7 +6,7 @@ description: |
 website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios
 support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios/issues
-published_at: 2023-06-29T14:52:50.04632+03:00
+published_at: 2023-07-03T12:09:01.788676+03:00
 source:
   git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-ios.git
   commit: 7363fae4635a1a46434d1bc1f5a1683f8a53415c


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3895)

- add custom provisioning profile file list
- add custom certificate file
- add support spaces in cert and provisioning file names
- add display parameters