### PR TITLE
run-tests-using-marathon-cloud 0.1.2

### DIFF
--- a/steps/run-tests-using-marathon-cloud/0.1.2/step.yml
+++ b/steps/run-tests-using-marathon-cloud/0.1.2/step.yml
@@ -1,0 +1,66 @@
+title: Run tests using Marathon Cloud
+summary: |
+  Run all your automated tests in just 15 minutes, no matter how many tests you have
+description: |
+  With this step you can easily run your Android instrumentation and iOS tests. Marathon Cloud is designed to run all your automated tests in just 15 minutes, no matter how many tests you have.
+website: https://marathonlabs.io
+source_code_url: https://github.com/MarathonLabs/bitrise-step-run-tests-using-marathon-cloud
+support_url: https://github.com/MarathonLabs/bitrise-step-run-tests-using-marathon-cloud/issues
+published_at: 2023-07-14T12:40:42.213318151+03:00
+source:
+  git: https://github.com/MarathonLabs/bitrise-step-run-tests-using-marathon-cloud.git
+  commit: e1c93a1527ff2afd59a08c8dc3906efde973ce76
+project_type_tags:
+- ios
+- android
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: malinskiy/tap/marathon-cloud
+inputs:
+- application: ""
+  opts:
+    description: "Application binary path.  \nFor an Android project: app APK file
+      path.  \nFor an iOS project: an ARM compatible Simulator build packaged in a
+      ZIP archive.  \n"
+    is_expand: true
+    is_required: true
+    summary: The application binary path refers to the APK file for Android or the
+      ZIP file for the iOS application.
+    title: App File
+- opts:
+    description: "Test application binary path.  \nFor an Android project: test app
+      APK file path.  \nFor an iOS project: an ARM compatible Simulator iOS Test Runner
+      app packaged in a ZIP archive.  \n"
+    is_expand: true
+    is_required: true
+    summary: The test application binary path refers to the APK file for Android or
+      the ZIP file for the iOS Test Runner app.
+    title: Test App File
+  test_application: ""
+- opts:
+    description: ""
+    is_expand: true
+    is_required: true
+    summary: Testing platform. `Android` or `iOS` only
+    title: Testing platform
+  platform: ""
+- api_key: null
+  opts:
+    description: "Have a look at [the tokens page](https://cloud.marathonlabs.io/tokens)
+      in the dashboard to obtain your token.      \n"
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: API key for authenticating with Marathon Cloud
+    title: Marathon Cloud API key
+- docker_image: marathonlabs/marathon-cloud:latest
+  opts:
+    description: ""
+    is_required: false
+    summary: You can specify your own custom image with a Docker Registry proxy here
+    title: Docker image to use for running marathon-cloud cli on Linux hosts

--- a/steps/run-tests-using-marathon-cloud/step-info.yml
+++ b/steps/run-tests-using-marathon-cloud/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3911)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.