### PR TITLE
activate-build-cache-for-tuist 1.0.4

### DIFF
--- a/steps/activate-build-cache-for-tuist/1.0.4/step.yml
+++ b/steps/activate-build-cache-for-tuist/1.0.4/step.yml
@@ -1,0 +1,21 @@
+title: Activate Bitrise Build Cache for Tuist
+summary: Activates Bitrise Remote Build Cache add-on for subsequent Tuist builds in
+  the workflow
+description: |
+  This Step activates Bitrise's remote build cache add-on for subsequent Tuist executions in the workflow.
+
+  After this Step executes, Tuist builds will automatically read from the remote cache and push new entries.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+published_at: 2023-07-25T09:58:01.891891+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache.git
+  commit: d8a26682256ef71b5ee0669c82935f02c9711391
+project_type_tags:
+- ios
+- macos
+type_tags:
+- utility
+is_skippable: true
+run_if: .IsCI


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3921)

https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache/releases/1.0.4

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
