### PR TITLE
codecov 3.3.2

### DIFF
--- a/steps/codecov/3.3.2/step.yml
+++ b/steps/codecov/3.3.2/step.yml
@@ -1,0 +1,66 @@
+title: Codecov
+summary: Upload your code coverage files to Codecov.io
+description: |-
+  Reduce technical debt with visualized test performance,
+  faster code reviews and workflow enhancements.
+  Now you can upload your code coverage files to Codecov every time you kick off a build!
+website: https://codecov.io
+source_code_url: https://github.com/codecov/codecov-bitrise
+support_url: https://community.codecov.io
+published_at: 2023-08-30T10:15:25.114054-07:00
+source:
+  git: https://github.com/codecov/codecov-bitrise.git
+  commit: 3eb71a9c1046c65138b5ef3d4b651806383d3e62
+type_tags:
+- test
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+inputs:
+- CODECOV_TOKEN: null
+  opts:
+    description: |
+      Codecov.io repository upload token
+    is_required: true
+    is_sensitive: true
+    title: Codecov.io token
+- OS: null
+  opts:
+    description: |
+      Name of the OS being used (options are "alpine" | "linux" | "macos")
+    is_required: true
+    is_sensitive: false
+    title: OS Name
+- VERSION: latest
+  opts:
+    description: |
+      Version of the Codecov Uploader to use (e.g. `v0.6.1`)
+    is_required: false
+    is_sensitive: false
+    title: Uploader Version
+- XCODE_ARCHIVE_PATH: null
+  opts:
+    description: |
+      --Deprecating-- Specify the xcode archive path. Likely specified as the -resultBundlePath and should end in .xcresult. Only needed if running with xcode support
+    title: '[Deprecating] Xcode archive path'
+- ENABLE_SWIFT_CONVERSION: null
+  opts:
+    description: |
+      Enable swift coverage conversation by setting to 'true'.
+    is_required: false
+    is_sensitive: false
+    title: Enable swift coverage
+- SWIFT_PROJECT: null
+  opts:
+    description: |
+      Specify the swift project. Will only work properly if ENABLE_SWIFT_CONVERSION is set to `true`
+    is_required: false
+    is_sensitive: false
+    title: Swift project name
+- opts:
+    description: |-
+      Options to pass along to the Codecov uploader.
+      You can use multiple options, separated by a space.
+      Review all options at https://github.com/codecov/uploader
+    title: Additional options for Codecov call
+  other_options: -C $GIT_CLONE_COMMIT_HASH


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=3979)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
