### PR TITLE
activate-build-cache-for-tuist 1.0.7 (tuist. 3.28.0)

### DIFF
--- a/steps/activate-build-cache-for-tuist/1.0.7/step.yml
+++ b/steps/activate-build-cache-for-tuist/1.0.7/step.yml
@@ -1,0 +1,21 @@
+title: Activate Bitrise Build Cache for Tuist
+summary: Activates Bitrise Remote Build Cache add-on for subsequent Tuist builds in
+  the workflow
+description: |
+  This Step activates Bitrise's remote build cache add-on for subsequent Tuist executions in the workflow.
+
+  After this Step executes, Tuist builds will automatically read from the remote cache and push new entries.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache
+published_at: 2023-10-04T14:11:45.96548-04:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache.git
+  commit: 5c17ce8e8593ab132a87756c87642d08dd0d3408
+project_type_tags:
+- ios
+- macos
+type_tags:
+- utility
+is_skippable: true
+run_if: .IsCI


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4010)

https://github.com/bitrise-steplib/bitrise-step-activate-tuist-cache/releases/1.0.7

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [V] __I will not move an already shared step version's tag to another commit__
- [V] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [V] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [V] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [V] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
