### PR TITLE
configcat-feature-flag-sync 0.0.7

### DIFF
--- a/steps/configcat-feature-flag-sync/0.0.7/step.yml
+++ b/steps/configcat-feature-flag-sync/0.0.7/step.yml
@@ -1,0 +1,70 @@
+title: ConfigCat Feature Flag Sync
+summary: Scans the source code for feature flags and uploads the references to the
+  ConfigCat Dashboard
+description: "This Step helps you get rid of technical debt by scanning the source
+  code and highlighting the feature flag usages for each feature flag on the [ConfigCat
+  Dashboard](https://app.configcat.com/).\n\n[ConfigCat](https://configcat.com/) is
+  a hosted service for feature flag and configuration management. It enables you to
+  decouple feature releases from code deployments. \n\n## Configuring the Step\n\n1.
+  Log in to [ConfigCat](https://app.configcat.com/)\n1. Create new [ConfigCat Public
+  Management API credentials](https://app.configcat.com/my-account/public-api-credentials/)
+  \n1. Store your credentials in the following Bitrise secret environment variables:
+  `CONFIGCAT_API_USER`, `CONFIGCAT_API_PASS`.\n1. Add your [ConfigCat config ID](https://configcat.com/docs/advanced/code-references/overview#config-id)
+  to the `ConfigCat Config ID` input variable of this step (`configcat_config_id`
+  in bitrise.yml). The config ID tells the step which feature flags it should search
+  for in your source code.\n\nFor more information about code reference scanning,
+  see the [documentation](https://configcat.com/docs/advanced/code-references/overview/).\n\n###
+  Code snippet on the ConfigCat Dashboard\n![Code references](https://configcat.com/docs/assets/cli/scan/scan_report.png)"
+website: https://configcat.com/
+source_code_url: https://github.com/configcat/bitrise-step-configcat-feature-flag-sync/
+support_url: https://configcat.com/support/
+published_at: 2023-10-12T21:45:01.677942+02:00
+source:
+  git: https://github.com/configcat/bitrise-step-configcat-feature-flag-sync.git
+  commit: 8c29c52d855ed7211c537485c49f8967d328942b
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+inputs:
+- configcat_api_host: api.configcat.com
+  opts:
+    is_required: true
+    summary: Full domain name without protocol e.g. 'api.configcat.com'
+    title: ConfigCat Public Management API host
+- configcat_config_id: null
+  opts:
+    is_required: true
+    summary: The [config ID](https://configcat.com/docs/advanced/code-references/overview#config-id)
+      tells the step which feature flags it should search for in your source code.
+    title: ConfigCat Config ID
+- line_count: 4
+  opts:
+    summary: The ConfigCat Dashboard will display a few lines of your source code
+      around the feature flag reference. You can set here how many lines of code you
+      want to include before and after the reference line.
+    title: 'Code snippet line count before and after the reference line (min: 1, max:
+      10)'
+- opts:
+    summary: e.g. 'subfolder/to/scan'
+    title: Sub-folder to scan, relative to the repository root folder
+  sub_folder: null
+- opts:
+    summary: Turns on or off detailed logging
+    title: Detailed logging
+    value_options:
+    - "false"
+    - "true"
+  verbose: "false"


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4022)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
