### PR TITLE
Activate Build Cache for Tuist step deprecation

### DIFF
--- a/steps/activate-build-cache-for-tuist/step-info.yml
+++ b/steps/activate-build-cache-for-tuist/step-info.yml
@@ -1,1 +1,3 @@
 maintainer: bitrise
+deprecate_notes: This step is deprecated. For more information please see: https://bitrise.io/blog/post/tuist-bitrise-build-cache-update
+removal_date: "2024-03-31"

--- a/steps/activate-build-cache-for-tuist/step-info.yml
+++ b/steps/activate-build-cache-for-tuist/step-info.yml
@@ -1,3 +1,3 @@
 maintainer: bitrise
-deprecate_notes: This step is deprecated. For more information please see: https://bitrise.io/blog/post/tuist-bitrise-build-cache-update
+deprecate_notes: "This step is deprecated. For more information please see: https://bitrise.io/blog/post/tuist-bitrise-build-cache-update"
 removal_date: "2024-03-31"


### PR DESCRIPTION
Deprecating the `Activate Build Cache for Tuist` step. For more details please see: https://bitrise.io/blog/post/tuist-bitrise-build-cache-update

