### PR TITLE
Deprecate legacy xctest-html-report step

### DIFF
--- a/steps/xctest-html-report/step-info.yml
+++ b/steps/xctest-html-report/step-info.yml
@@ -1,1 +1,4 @@
 maintainer: community
+removal_date: "2023-11-30"
+deprecate_notes: |
+ This step is no longer maintained. To generate HTML reports from xcresult files use the new "Generate Xcode test report html" step.

--- a/steps/xctest-html-report/step-info.yml
+++ b/steps/xctest-html-report/step-info.yml
@@ -1,4 +1,4 @@
 maintainer: community
 removal_date: "2023-11-30"
 deprecate_notes: |
- This step is no longer maintained. To generate HTML reports from xcresult files use the new "Generate Xcode test report html" step.
+ This step is no longer maintained. To generate HTML reports from xcresult files use the new official Bitrise step: "Generate Xcode test report html" (https://github.com/bitrise-steplib/bitrise-step-generate-xcode-html-report).

--- a/steps/xctest-html-report/step-info.yml
+++ b/steps/xctest-html-report/step-info.yml
@@ -1,4 +1,4 @@
 maintainer: community
 removal_date: "2023-11-30"
 deprecate_notes: |
- This step is no longer maintained. To generate HTML reports from xcresult files use the new official Bitrise step: "Generate Xcode test report html" (https://github.com/bitrise-steplib/bitrise-step-generate-xcode-html-report).
+ This step is no longer maintained. To generate HTML reports from xcresult files use the new official Bitrise step: "Generate Xcode test report html" (https://devcenter.bitrise.io/en/testing/testing-ios-apps/viewing-xcode-test-results-in-rich-html-format.html).


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
