### PR TITLE
bitrise-step-activate-bazel-cache 1.0.0

### DIFF
--- a/steps/bitrise-step-activate-bazel-cache/1.0.0/step.yml
+++ b/steps/bitrise-step-activate-bazel-cache/1.0.0/step.yml
@@ -1,0 +1,17 @@
+title: Activate Bitrise Build Cache for Bazel
+summary: |
+  Activates Bitrise Remote Build Cache add-on for subsequent Bazel builds in the workflows
+description: |
+  This Step activates Bitrise's remote build cache add-on for subsequent Bazel executions in the workflow.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-bazel-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-bazel-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-bazel-cache/issues
+published_at: 2023-10-30T13:09:17.154812-07:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-bazel-cache.git
+  commit: 81966a61fc72b5035a3bd3202e95b903a36291c6
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh

--- a/steps/bitrise-step-activate-bazel-cache/step-info.yml
+++ b/steps/bitrise-step-activate-bazel-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/bitrise-step-activate-bazel-cache/step-info.yml
+++ b/steps/bitrise-step-activate-bazel-cache/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4039)

https://github.com/bitrise-steplib/bitrise-step-activate-bazel-cache/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.