### PR TITLE
dsym-upload-to-crashlytics-spm 0.0.1

### DIFF
--- a/steps/dsym-upload-to-crashlytics--no-cocoapods/0.0.1/step.yml
+++ b/steps/dsym-upload-to-crashlytics--no-cocoapods/0.0.1/step.yml
@@ -1,0 +1,35 @@
+title: Firebase dSym Upload (SPM installation)
+summary: |
+  Upload of dSym to Firebase Crashlytics with SPM installation
+description: |
+  This step will help you to upload dSym of your build to Firebase Crashlytics with SPM installation.
+website: https://github.com/hughmaurer/bitrise-step-dsym-upload-to-crashlytics--no-cocoapods
+source_code_url: https://github.com/hughmaurer/bitrise-step-dsym-upload-to-crashlytics--no-cocoapods
+support_url: https://github.com/hughmaurer/bitrise-step-dsym-upload-to-crashlytics--no-cocoapods/issues
+published_at: 2023-12-20T12:22:50.911776+01:00
+source:
+  git: https://github.com/hughmaurer/bitrise-step-dsym-upload-to-crashlytics--no-cocoapods.git
+  commit: 5613b9ade23a2f1472fe11eaa9e59da904d537d2
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- google_plist_path: null
+  opts:
+    description: |
+      The location is usually in the form ./YOUR-APP-NAME/GoogleService-Info.plist
+    is_required: true
+    title: Location of your GoogleService info plist
+- dsym_location: $BITRISE_DSYM_PATH
+  opts:
+    description: |
+      This is the location of your dSYMs. Usually it is $BITRISE\_DSYM\_PATH
+    is_expand: true
+    is_required: true
+    summary: This is the location of your dSYMs that you want to upload to Firebase.
+    title: Location of the bitrise dSYMs

--- a/steps/dsym-upload-to-crashlytics--no-cocoapods/step-info.yml
+++ b/steps/dsym-upload-to-crashlytics--no-cocoapods/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4073)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.