### PR TITLE
instabug-ios-symbol-upload 1.0.2

### DIFF
--- a/steps/instabug-ios-symbol-upload/1.0.2/step.yml
+++ b/steps/instabug-ios-symbol-upload/1.0.2/step.yml
@@ -1,0 +1,40 @@
+title: Instabug iOS Symbol Upload
+summary: This step uploads iOS debug symbols to Instabug through Bitrise CI integration.
+description: |-
+  Upload iOS debug symbols to Instabug through Bitrise CI.
+
+  ### Configuring the Step
+  1. Add the **Instabug iOS Symbol Upload** Step to your Workflow after any build Step.
+  2. Set the **Working directory**.
+  3. Set the **Instabug App Token**. It's highly recommended to have this value in an env var and reference that.
+
+  ### Troubleshooting
+  Make sure you insert the Step before any build Step so that every dependency is downloaded a build Step starts running.
+website: https://github.com/mendozammatias/bitrise-step-instabug-ios-symbol-upload
+source_code_url: https://github.com/mendozammatias/bitrise-step-instabug-ios-symbol-upload
+support_url: https://github.com/mendozammatias/bitrise-step-instabug-ios-symbol-upload/issues
+published_at: 2024-02-09T14:27:18.37993-03:00
+source:
+  git: https://github.com/mendozammatias/bitrise-step-instabug-ios-symbol-upload.git
+  commit: 1dd4260047cbbcbddf12678ff5cb3b9679cd48ec
+project_type_tags:
+- ios
+- xamarin
+- react-native
+- cordova
+- flutter
+type_tags:
+- artifact-info
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- instabug_app_token: $INSTABUG_APP_TOKEN
+  opts:
+    is_required: true
+    summary: Instabug App Token for the given environment.
+    title: Instabug App Token
+- opts:
+    summary: Working directory of the step. You can leave it empty to not change it.
+    title: Working directory
+  workdir: $BITRISE_SOURCE_DIR

--- a/steps/instabug-ios-symbol-upload/step-info.yml
+++ b/steps/instabug-ios-symbol-upload/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4108)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.