### PR TITLE
instabug-android-mapping-file-upload 1.0.1

### DIFF
--- a/steps/instabug-android-mapping-file-upload/1.0.1/step.yml
+++ b/steps/instabug-android-mapping-file-upload/1.0.1/step.yml
@@ -1,0 +1,52 @@
+title: Instabug Android Mapping File Upload
+summary: |
+  This step uploads Android mapping file to Instabug through Bitrise CI integration.
+description: |
+  Upload Android mapping file to Instabug through Bitrise CI.
+
+  ### Configuring the Step
+  1. Add the **Instabug Android Mapping File Upload** step to your Workflow after any build Step.
+  2. Set the **build.gradle Path**. In general, it should work with the default value.
+  3. Set the **Instabug App Token**. It's highly recommended to have this value in an env var and reference that.
+
+
+  ### Troubleshooting
+  Make sure you insert the Step after any build Step so that every dependency and env var is already setted.
+website: https://github.com/mendozammatias/bitrise-step-instabug-android-mapping-file-upload
+source_code_url: https://github.com/mendozammatias/bitrise-step-instabug-android-mapping-file-upload
+support_url: https://github.com/mendozammatias/bitrise-step-instabug-android-mapping-file-upload/issues
+published_at: 2024-02-12T16:00:48.549611-03:00
+source:
+  git: https://github.com/mendozammatias/bitrise-step-instabug-android-mapping-file-upload.git
+  commit: d7d78718080ea367c6364a06a92a93b32af5480a
+project_type_tags:
+- ios
+- xamarin
+- react-native
+- cordova
+- flutter
+type_tags:
+- artifact-info
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- build_gradle_path: $BITRISE_SOURCE_DIR/android/app/build.gradle
+  opts:
+    is_required: true
+    summary: build.gradle file path. In general, it should work with the default value.
+    title: build.gradle Path.
+- instabug_app_token: $INSTABUG_APP_TOKEN
+  opts:
+    is_required: true
+    summary: Instabug App Token for the given environment.
+    title: Instabug App Token
+outputs:
+- VERSION_CODE: null
+  opts:
+    summary: Version Code extracted from build.gradle file.
+    title: Version Code
+- VERSION_NAME: null
+  opts:
+    summary: Version Name extracted from build.gradle file.
+    title: Version Name

--- a/steps/instabug-android-mapping-file-upload/step-info.yml
+++ b/steps/instabug-android-mapping-file-upload/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4112)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.