### PR TITLE
bitrise-step-create-github-pull-request 0.0.1

### DIFF
--- a/steps/bitrise-step-create-github-pull-request/0.0.1/step.yml
+++ b/steps/bitrise-step-create-github-pull-request/0.0.1/step.yml
@@ -1,0 +1,77 @@
+title: |
+  Create GitHub Pull Request
+summary: |
+  Creates a pull request on GitHub with the specified details.
+description: |
+  This step creates a pull request on GitHub using the provided branch names, title, body, and GitHub token.
+website: https://github.com/Ahmadalsofi/bitrise-step-create-github-pull-request
+source_code_url: https://github.com/Ahmadalsofi/bitrise-step-create-github-pull-request
+support_url: https://github.com/Ahmadalsofi/bitrise-step-create-github-pull-request/issues
+published_at: 2024-02-23T01:33:29.490604+03:00
+source:
+  git: https://github.com/Ahmadalsofi/bitrise-step-create-github-pull-request.git
+  commit: 4c7cbb34f6ca718e9e158760df7dd0225128ec82
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+run_if: ""
+inputs:
+- from_branch: ""
+  opts:
+    description: Enter the name of the source branch from which changes will be pulled.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Specify the source branch for the pull request.
+    title: From Branch
+- opts:
+    description: Enter the name of the target branch to which changes will be merged.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Specify the target branch for the pull request.
+    title: To Branch
+  to_branch: ""
+- opts:
+    description: Enter a descriptive title for the pull request.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Provide a title for the pull request.
+    title: Pull Request Title
+  pr_title: ""
+- opts:
+    description: Enter a detailed description for the pull request.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Provide a description for the pull request.
+    title: Pull Request Body
+  pr_body: ""
+- github_token: ""
+  opts:
+    description: Enter the GitHub token used to authenticate the API request.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    summary: Provide the GitHub token for authentication.
+    title: GitHub Token
+- opts:
+    description: Enter the name of the GitHub repository where the pull request will
+      be created.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Provide the name of the GitHub repository.
+    title: Repository Name
+  repo_name: ""
+outputs:
+- PR_HTML_URL: null
+  opts:
+    summary: URL of the created pull request.
+    title: Pull Request URL

--- a/steps/bitrise-step-create-github-pull-request/step-info.yml
+++ b/steps/bitrise-step-create-github-pull-request/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4126)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.