### PR TITLE
datadog-mobile-app-upload 1.0.0

### DIFF
--- a/steps/datadog-mobile-app-upload/1.0.0/step.yml
+++ b/steps/datadog-mobile-app-upload/1.0.0/step.yml
@@ -1,0 +1,56 @@
+title: datadog-mobile-app-upload
+summary: |
+  Step to upload a new version of you application to Datadog for Synthetics tests
+description: |
+  With the `synthetics-test-automation-bitrise-step-upload-application` step you can upload a new version of your application to Datadog to run Synthetics tests against during your Bitrise CI and ensure all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle.
+website: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
+source_code_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
+support_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/issues
+published_at: 2024-03-01T11:49:05.282524+01:00
+source:
+  git: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git
+  commit: a2814456ca39b76defbc21eaf1256ce19c261690
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: ./upload-application.sh
+inputs:
+- api_key: $DATADOG_API_KEY
+  opts:
+    description: The API key used to query the Datadog API.
+    is_expand: true
+    is_required: true
+    title: Datadog API Key
+- app_key: $DATADOG_APP_KEY
+  opts:
+    description: The application key used to query the Datadog API.
+    is_expand: true
+    is_required: true
+    title: Datadog APP Key
+- config_path: ""
+  opts:
+    description: The global JSON configuration used when launching tests.
+    title: Global JSON configuration
+- latest: false
+  opts:
+    description: Marks the application as `latest`. Any tests that run on the latest
+      version will use this version on their next run.
+    title: Latest
+- mobile_application_id: ""
+  opts:
+    description: ID of the application you want to upload the new version to.
+    title: Mobile Application ID
+- mobile_application_version_file_path: ""
+  opts:
+    description: Override the mobile application with a local or recently built application.
+    title: Mobile Application Version File Path
+- opts:
+    description: The Datadog site to send data to. If the `DD_SITE` environment variable
+      is set, it takes preference.
+    title: Datadog Site
+  site: datadoghq.com
+- opts:
+    description: Name of the new version. It has to be unique.
+    title: Version Name
+  version_name: ""

--- a/steps/datadog-mobile-app-upload/1.0.0/step.yml
+++ b/steps/datadog-mobile-app-upload/1.0.0/step.yml
@@ -1,15 +1,30 @@
-title: datadog-mobile-app-upload
+title: Datadog Mobile App Upload
 summary: |
-  Step to upload a new version of you application to Datadog for Synthetics tests
+  Step to upload a new version of you application to Datadog for Synthetic tests
 description: |
-  With the `synthetics-test-automation-bitrise-step-upload-application` step you can upload a new version of your application to Datadog to run Synthetics tests against during your Bitrise CI and ensure all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle.
+  Step to upload a new version of you application to Datadog for Synthetic tests
+
+  With this Step you can upload a new version of your application to Datadog to run Synthetic tests against during your Bitrise CI and ensure all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle.
+
+  To use this Step:
+  - Create Synthetic mobile tests in Datadog. As part of this you'll be asked to add a mobile application. An existing mobile application is a prerequisite for this command. See [Continuous Testing and CI/CD Configuration documentation](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration?tab=npm) at the bottom of the page for more information.
+  - Upload and build your app in the CI.
+  - Configure and run this Step in your Bitrise workflow to upload a new version of your application to Datadog to test against.
+
+  This Step will:
+  - Upload a new version of an already existing application to Datadog to be used for testing.
+
+  For examples of how the inputs of this Step can be configured check the [README for this step](https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application)
 website: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
 source_code_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
 support_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/issues
-published_at: 2024-03-01T11:49:05.282524+01:00
+published_at: 2024-03-12T17:59:21.223521+01:00
 source:
   git: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git
-  commit: a2814456ca39b76defbc21eaf1256ce19c261690
+  commit: f6d1c21895103d801aaf18c133408a2f7776acbe
+project_type_tags:
+- ios
+- android
 type_tags:
 - test
 toolkit:
@@ -18,39 +33,47 @@ toolkit:
 inputs:
 - api_key: $DATADOG_API_KEY
   opts:
+    category: Required Inputs
     description: The API key used to query the Datadog API.
     is_expand: true
     is_required: true
     title: Datadog API Key
 - app_key: $DATADOG_APP_KEY
   opts:
+    category: Required Inputs
     description: The application key used to query the Datadog API.
     is_expand: true
     is_required: true
     title: Datadog APP Key
 - config_path: ""
   opts:
+    category: Optional Inputs
     description: The global JSON configuration used when launching tests.
     title: Global JSON configuration
 - latest: false
   opts:
+    category: Optional Inputs
     description: Marks the application as `latest`. Any tests that run on the latest
       version will use this version on their next run.
     title: Latest
 - mobile_application_id: ""
   opts:
+    category: Optional Inputs
     description: ID of the application you want to upload the new version to.
     title: Mobile Application ID
 - mobile_application_version_file_path: ""
   opts:
+    category: Optional Inputs
     description: Override the mobile application with a local or recently built application.
     title: Mobile Application Version File Path
 - opts:
+    category: Optional Inputs
     description: The Datadog site to send data to. If the `DD_SITE` environment variable
       is set, it takes preference.
     title: Datadog Site
   site: datadoghq.com
 - opts:
+    category: Optional Inputs
     description: Name of the new version. It has to be unique.
     title: Version Name
   version_name: ""

--- a/steps/datadog-mobile-app-upload/step-info.yml
+++ b/steps/datadog-mobile-app-upload/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4138)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.