### PR TITLE
activate-build-cache-for-bazel 1.0.0

### DIFF
--- a/steps/activate-build-cache-for-bazel/1.0.0/step.yml
+++ b/steps/activate-build-cache-for-bazel/1.0.0/step.yml
@@ -1,0 +1,21 @@
+title: Activate Bitrise Build Cache for Bazel
+summary: |
+  Activates Bitrise Remote Build Cache for subsequent Bazel builds in the workflows.
+description: |
+  This Step activates Bitrise's remote build cache add-on for subsequent Bazel executions in the workflow.
+
+  After this Step executes, Bazel builds will automatically read from the remote cache and push new entries if it's enabled.
+website: https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-bazel
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-bazel
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-bazel/issues
+published_at: 2024-03-19T13:54:48.081077+01:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-bazel.git
+  commit: 77c5bb89d3c255f6961b944b60184d23e74d4225
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_skippable: true
+run_if: .IsCI

--- a/steps/activate-build-cache-for-bazel/step-info.yml
+++ b/steps/activate-build-cache-for-bazel/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/activate-build-cache-for-bazel/step-info.yml
+++ b/steps/activate-build-cache-for-bazel/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4151)

https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-bazel/releases/1.0.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.