### PR TITLE
datadog-mobile-app-upload 1.0.2

### DIFF
--- a/steps/datadog-mobile-app-upload/1.0.2/step.yml
+++ b/steps/datadog-mobile-app-upload/1.0.2/step.yml
@@ -1,0 +1,89 @@
+title: Datadog Mobile App Upload
+summary: |
+  Step to upload a new version of you application to Datadog for Synthetic tests
+description: |
+  Step to upload a new version of you application to Datadog for Synthetic tests
+
+  With this Step you can upload a new version of your application to Datadog to run Synthetic tests against during your Bitrise CI and ensure all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle.
+
+  To use this Step:
+  - Create Synthetic mobile tests in Datadog. As part of this you'll be asked to add a mobile application. An existing mobile application is a prerequisite for this command. See [Continuous Testing and CI/CD Configuration documentation](https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration?tab=npm) at the bottom of the page for more information.
+  - Upload and build your app in the CI.
+  - Configure and run this Step in your Bitrise workflow to upload a new version of your application to Datadog to test against.
+
+  This Step will:
+  - Upload a new version of an already existing application to Datadog to be used for testing.
+
+  For examples of how the inputs of this Step can be configured check the [README for this step](https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application)
+website: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
+source_code_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application
+support_url: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/issues
+published_at: 2024-04-29T13:19:59.569733+02:00
+source:
+  git: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git
+  commit: 21645b9bfc3b69ec65852d73690e919130799bde
+project_type_tags:
+- ios
+- android
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: ./upload-application.sh
+inputs:
+- api_key: $DATADOG_API_KEY
+  opts:
+    category: Required Inputs
+    description: The API key used to query the Datadog API.
+    is_expand: true
+    is_required: true
+    title: Datadog API Key
+- app_key: $DATADOG_APP_KEY
+  opts:
+    category: Required Inputs
+    description: The application key used to query the Datadog API.
+    is_expand: true
+    is_required: true
+    title: Datadog APP Key
+- config_path: ""
+  opts:
+    category: Optional Inputs
+    description: The global JSON configuration used when launching tests.
+    title: Global JSON configuration
+- latest: false
+  opts:
+    category: Optional Inputs
+    description: Marks the application as `latest`. Any tests that run on the latest
+      version will use this version on their next run.
+    title: Latest
+- mobile_application_id: ""
+  opts:
+    category: Required Inputs
+    description: ID of the application you want to upload the new version to.
+    is_required: true
+    title: Mobile Application ID
+- mobile_application_version_file_path: ""
+  opts:
+    category: Required Inputs
+    description: Override the mobile application with a local or recently built application.
+    is_required: true
+    title: Mobile Application Version File Path
+- opts:
+    category: Optional Inputs
+    description: The Datadog site to send data to. If the `DD_SITE` environment variable
+      is set, it takes preference.
+    title: Datadog Site
+  site: datadoghq.com
+- opts:
+    category: Required Inputs
+    description: Name of the new version. It has to be unique.
+    is_required: true
+    title: Version Name
+  version_name: ""
+outputs:
+- DATADOG_UPLOADED_APPLICATION_VERSION_ID: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
+  opts:
+    category: Outputs
+    description: The ID of the uploaded application version, which can be used by
+      the run-tests step.
+    title: Datadog Uploaded Application Version ID


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4179)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
