### PR TITLE
appdome-build-2secure-android 3.1.2

### DIFF
--- a/steps/appdome-build-2secure-android/3.1.2/step.yml
+++ b/steps/appdome-build-2secure-android/3.1.2/step.yml
@@ -1,0 +1,172 @@
+title: Appdome-Build-2Secure for Android
+summary: |
+  Builds a mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, building and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android/issues
+published_at: 2024-07-22T11:21:43.543726+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git
+  commit: c64c92acd47eb194699d5ab04c23807d8c73ac50
+project_type_tags:
+- android
+type_tags:
+- build
+- code-sign
+- security
+toolkit:
+  bash:
+    entry_file: step_init.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+inputs:
+- app_location: null
+  opts:
+    is_required: true
+    summary: URL to app file (apk/aab) or an EnvVar representing its path (i.e. $BITRISE_APK_PATH
+      or $BITRISE_AAB_PATH)
+    title: App file URL or EnvVar
+- opts:
+    is_required: false
+    summary: Output app file name. The file extension (aab/apk) will be the same as
+      the original app. If not specified, the default output file will be same as
+      the original app but with Appdome_ prefix.
+    title: Output file name (without extension)
+  output_filename: null
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- certificate_file: null
+  opts:
+    description: 'Code signing keystore evironment variable name (as appears in the
+      App Settings->Code Signing section) to use. If not provided, the FIRST certificate
+      among the uploaded files to ''App Settings->Code signing'' section will be used.
+      Only ONE certificate file is supported. For example: $BITRISEIO_ANDROID_KEYSTORE_URL'
+    is_required: false
+    title: Code signing keystore evironment variable name (required for On-Appdome
+      signing method)
+- keystore_password: null
+  opts:
+    description: 'Code signing keystore password evironment variable name (as appears
+      in the App Settings->Code Signing section-><keystore file>) to use. Must be
+      provided if certificate file was provided. For example: $BITRISEIO_ANDROID_KEYSTORE_PASSWORD'
+    is_required: false
+    title: Keystore password evironment variable name (required for On-Appdome signing
+      method)
+- keystore_alias: null
+  opts:
+    description: 'Code signing keystore alias evironment variable name (as appears
+      in the App Settings->Code Signing section-><keystore file>) to use. Must be
+      provided if certificate file was provided. For example: $BITRISEIO_ANDROID_KEYSTORE_ALIAS'
+    is_required: false
+    title: Keystore alias evironment variable name (required for On-Appdome signing
+      method)
+- opts:
+    description: 'Code signing private key password evironment variable name (as appears
+      in the App Settings->Code Signing section-><keystore file>) to use. Must be
+      provided if certificate file was provided. For example: $BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD'
+    is_required: false
+    title: Keystore private key password evironment variable name (required for On-Appdome
+      signing method)
+  private_key_password: null
+- gp_signing: "false"
+  opts:
+    category: Google Signing
+    description: Sign the app for Google Play? If 'true', requires $SIGN_FINGERPRINT
+      in the Secrets tab.
+    is_required: true
+    title: Google Play Signing
+    value_options:
+    - "true"
+    - "false"
+- google_fingerprint: $GOOGLE_SIGN_FINGERPRINT
+  opts:
+    category: Google Signing
+    description: Google Sign Fingerprint for Google Play singing, or its Secret variable
+      name.
+    is_required: false
+    title: Google Sign Fingerprint
+- fingerprint: $SIGN_FINGERPRINT
+  opts:
+    category: Private/Auto-Dev Signing
+    description: Sign Fingerprint (not for Google Play singing), or its Secret variable
+      name.
+    is_required: false
+    title: Sign Fingerprint
+- opts:
+    description: Select 'true' to create a Universal.apk file (applies to .aab app
+      types only).
+    is_required: false
+    title: Secondary Output
+    value_options:
+    - "true"
+    - "false"
+  secondary_output: "false"
+- build_logs: "false"
+  opts:
+    description: Build the app with Appdome's Diagnostic Logs
+    is_required: true
+    title: Build With Diagnostic Logs
+    value_options:
+    - "true"
+    - "false"
+- build_to_test: None
+  opts:
+    description: Select a device cloud vendor this build will be ready for testing
+      on. Select None for a production build or for a vendor not in the list.
+    is_required: true
+    title: Build to test Vendor
+    value_options:
+    - None
+    - Bitbar
+    - Browserstack
+    - Saucelabs
+    - Lambdatest
+outputs:
+- APPDOME_SECURED_APK_PATH: null
+  opts:
+    description: |
+      Local path of the secured .apk file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .apk file
+    title: Secured .apk file path
+- APPDOME_SECURED_AAB_PATH: null
+  opts:
+    description: |
+      Local path of the secured .aab file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .aab file
+    title: Secured .aab file path
+- APPDOME_SECURED_SO_PATH: null
+  opts:
+    description: |
+      Local path of the secured secondary output file (universal apk). Available if Secondary Output is set to 'true' and the original app is .aab type
+    summary: Local path of the secured secondary output file
+    title: Secured secondary output file path (universal apk)
+- APPDOME_PRIVATE_SIGN_SCRIPT_PATH: null
+  opts:
+    description: |
+      Local path of the .sh sign script file. Available when 'Signing Method' set to 'Auto-Dev-Signing'
+    summary: Local path of the .sh sign script file
+    title: .sh sign script file path
+- APPDOME_CERTIFICATE_PATH: null
+  opts:
+    summary: Local path of the Certified Secure Certificate .pdf file
+    title: Certified Secure Certificate .pdf file path


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4240)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
