### PR TITLE
disable-iphonesimulator-connect-hardware-keyboard 0.1.0

### DIFF
--- a/steps/disable-iphonesimulator-connect-hardware-keyboard/0.1.0/step.yml
+++ b/steps/disable-iphonesimulator-connect-hardware-keyboard/0.1.0/step.yml
@@ -1,0 +1,36 @@
+title: Disable iphonesimulator ConnectHardwareKeyboard preference
+summary: |
+  This Step disables ConnectHardwareKeyboard preference for all iphonesimulator devices.
+website: https://github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard
+source_code_url: https://github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard
+support_url: https://github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard/issues
+published_at: 2024-11-08T15:25:10.647718+01:00
+source:
+  git: https://github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard.git
+  commit: ef0f68a586922edd52267017981fe4a5c34fd408
+project_type_tags:
+- ios
+- react-native
+- cordova
+- ionic
+- flutter
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard
+inputs:
+- iphonesimulator_preferences_pth: ~/Library/Preferences/com.apple.iphonesimulator.plist
+  opts:
+    is_dont_change_value: true
+    is_required: true
+    summary: The path of the iphonesimulator preferences file.
+    title: iphonesimulator preferences path
+- opts:
+    is_required: true
+    summary: Print verbose information.
+    title: Verbose
+    value_options:
+    - "yes"
+    - "no"
+  verbose: "no"

--- a/steps/disable-iphonesimulator-connect-hardware-keyboard/step-info.yml
+++ b/steps/disable-iphonesimulator-connect-hardware-keyboard/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community

--- a/steps/disable-iphonesimulator-connect-hardware-keyboard/step-info.yml
+++ b/steps/disable-iphonesimulator-connect-hardware-keyboard/step-info.yml
@@ -1,1 +1,1 @@
-maintainer: community
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4311)

https://github.com/bitrise-steplib/steps-disable-iphonesimulator-connect-hardware-keyboard/releases/0.1.0

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.