### PR TITLE
set-pubspec-application-version 1.0.0

### DIFF
--- a/steps/set-pubspec-application-version/1.0.0/step.yml
+++ b/steps/set-pubspec-application-version/1.0.0/step.yml
@@ -1,0 +1,67 @@
+title: Set pubspec version and build number
+summary: Sets application version and build number in pubspec file and returns the
+  new version info
+description: Sets the application version by the inputs for application version and
+  build number. The application build number and the project root are mandatory to
+  provide as inputs.
+website: https://github.com/milkinteractive/bitrise-step-set-pubspec-application-version
+source_code_url: https://github.com/milkinteractive/bitrise-step-set-pubspec-application-version
+support_url: https://github.com/milkinteractive/bitrise-step-set-pubspec-application-version/issues
+published_at: 2025-01-07T16:37:40.408921+01:00
+source:
+  git: https://github.com/milkinteractive/bitrise-step-set-pubspec-application-version.git
+  commit: 7d9059495db5db82e84fe74d97b0a94fefc01b76
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- flutter
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: true
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: The root directory of your Flutter or Dart project that contains
+      the *pubspec.yaml* file which is in general accessible over the $BITRISE_SOURCE_DIR
+      variable.
+    is_required: true
+    summary: The root directory of your Flutter or Dart project i.e. from $BITRISE_SOURCE_DIR
+    title: Project Location
+  project_location: $BITRISE_SOURCE_DIR
+- bitrise_buildnumber: $BITRISE_BUILD_NUMBER
+  opts:
+    description: The application build number which could be used with variable $BITRISE_BUILD_NUMBER.
+    is_required: true
+    summary: Application build number i.e. from $BITRISE_BUILD_NUMBER.
+    title: Application build number
+- application_version: null
+  opts:
+    description: The application version which could be empty, then it is keeped like
+      it is, or set by this input.
+    is_required: false
+    summary: The application version info as a string like 1.2.3
+    title: Application version
+outputs:
+- DART_PUBSPEC_APP_VERSION: null
+  opts:
+    description: The application version which is set in the pubspec.yaml version
+      string at the **project location**.
+    title: Flutter / Dart pubspec application version which was new set or already
+      set as input.
+- DART_PUBSPEC_APP_BUILD_NUMBER: null
+  opts:
+    description: The application build number is set in the pubspec.yaml version string
+      at the **project location**.
+    title: Flutter / Dart pubspec application build number which was set as input.
+- DART_PUBSPEC_APP_VERSION_STRING: null
+  opts:
+    description: The application version string with version+buildnumber like 1.2.3+999
+      which was set in the pubspec.yaml at the **project location**.
+    title: Flutter / Dart pubspec application version string with version+buildnumber
+      which is set in pubspec.yaml.


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4336)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


# Change

The change is that it is supported only for dart version 3 and above. Before dart version 2 was supported. It is a major breaking change.