### PR TITLE
bitrise-step-code-signing-setting-patch 1.0.5

### DIFF
--- a/steps/bitrise-step-code-signing-setting-patch/1.0.5/step.yml
+++ b/steps/bitrise-step-code-signing-setting-patch/1.0.5/step.yml
@@ -1,0 +1,154 @@
+title: Code Signing Setting Patch
+summary: |
+  Patch xcode's signing config for specific key and provisioning profile
+description: |
+  Patch xcode's signing config for specific key and provisioning profile
+website: https://github.com/j796160836/bitrise-step-code-signing-setting-patch
+source_code_url: https://github.com/j796160836/bitrise-step-code-signing-setting-patch
+support_url: https://github.com/j796160836/bitrise-step-code-signing-setting-patch/issues
+published_at: 2025-01-20T23:47:12.763332+08:00
+source:
+  git: https://github.com/j796160836/bitrise-step-code-signing-setting-patch.git
+  commit: b3310ccb1c8bbc2eeddd7337441220b4ef9a0574
+host_os_tags:
+- osx-10.10
+project_type_tags:
+- ios
+type_tags:
+- utility
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- opts:
+    description: "Your project.xcodeproj file path. (e.g. MyAwesomeProject/MyAwesomeProject.xcodeproj)
+      \ \nEven if provide `.xcodeproj` path even if using `.xcworkspace`.\n"
+    is_expand: true
+    is_required: true
+    summary: Your project.xcodeproj file path.
+    title: Xcode project.xcodeproj Path
+    value_options: []
+  xcode_xcodeproj_file: null
+- opts:
+    description: |
+      Your target name of your xcode project. (e.g. MyAwesomeProject)
+    is_expand: true
+    is_required: true
+    summary: Project Target Name
+    title: Project Target
+    value_options: []
+  project_target: null
+- code_sign_style: Automatic
+  opts:
+    description: "The **CODE__SIGN__STYLE** value will be replaced.  \nValue either
+      `Automatic` or `Manual`.\n"
+    is_expand: true
+    is_required: true
+    summary: The **CODE__SIGN__STYLE** value will be replaced.
+    title: Code Sign Style
+    value_options:
+    - Automatic
+    - Manual
+- debug_development_configuration: null
+  opts:
+    description: |
+      The **debug configuration** value will be replaced.
+      Please set your value, or by default you have to use `Debug`.
+    is_expand: true
+    is_required: true
+    summary: The **debug configuration** value will be replaced.
+    title: Development Configuration (Debug)
+    value_options: []
+- debug_development_team: null
+  opts:
+    description: |
+      The **debug configurations** of **DEVELOPMENT_TEAM** value will be replaced.
+      Left blank means `None`.
+    is_expand: true
+    is_required: false
+    summary: The **debug configurations** of **DEVELOPMENT_TEAM** value will be replaced.
+    title: Development Team (Debug)
+    value_options: []
+- debug_code_sign_identity: null
+  opts:
+    description: "The **debug configurations** of **CODE__SIGN__IDENTITY** value will
+      be replaced.   \nValue will be `iPhone Developer`, `iPhone Distribution` or
+      others.\n"
+    is_expand: true
+    is_required: true
+    summary: The **debug configurations** of **CODE__SIGN__IDENTITY** value will be
+      replaced.
+    title: Code Sign Identity (Debug)
+    value_options: []
+- debug_provisioning_profile_specifier: null
+  opts:
+    description: "The **debug configurations** of **PROVISIONING__PROFILE__SPECIFIER**
+      value will be replaced.  \nPlease specify the provisioning profile name which
+      is same as one created at **Certificates, Identifiers & Profiles** at **Apple
+      Developer Program**.  \nDon't foget to upload that provisioning profile file.\n"
+    is_expand: true
+    is_required: true
+    summary: The **debug configurations** of **PROVISIONING__PROFILE__SPECIFIER**
+      value will be replaced.
+    title: Provisioning Profile Specifier (Debug)
+    value_options: []
+- opts:
+    description: |
+      The **release configuration** value will be replaced.
+      Please set your value, or by default you have to use `Release`.
+    is_expand: true
+    is_required: true
+    summary: The **release configuration** value will be replaced.
+    title: Release Configuration (Release)
+    value_options: []
+  release_configuration: null
+- opts:
+    description: "The **release configurations** of **DEVELOPMENT_TEAM** value will
+      be replaced.  \nLeft blank means `None`.\n"
+    is_expand: true
+    is_required: false
+    summary: The **release configurations** of **DEVELOPMENT_TEAM** value will be
+      replaced.
+    title: Development Team (Release)
+    value_options: []
+  release_development_team: null
+- opts:
+    description: "The **release configurations** of **CODE__SIGN__IDENTITY** value
+      will be replaced.   \nValue will be `iPhone Developer`, `iPhone Distribution`
+      or others.\n"
+    is_expand: true
+    is_required: true
+    summary: The **release configurations** of **CODE__SIGN__IDENTITY** value will
+      be replaced.
+    title: Code Sign Identity (Release)
+    value_options: []
+  release_code_sign_identity: null
+- opts:
+    description: "The **release configurations** of **PROVISIONING__PROFILE__SPECIFIER**
+      value will be replaced.  \nPlease specify the provisioning profile name which
+      is same as one created at **Certificates, Identifiers & Profiles** at **Apple
+      Developer Program**.  \nDon't foget to upload that provisioning profile file.\n"
+    is_expand: true
+    is_required: true
+    summary: The **release configurations** of **PROVISIONING__PROFILE__SPECIFIER**
+      value will be replaced.
+    title: Provisioning Profile Specifier (Release)
+    value_options: []
+  release_provisioning_profile_specifier: null
+- dry_run: "no"
+  opts:
+    description: |
+      If set this value `yes`, it will Dry-run this steps to preview the signing settings.
+    is_expand: true
+    is_required: true
+    summary: If set this value `yes`, it will Dry-run this steps to preview the signing
+      settings.
+    title: Dry-run preview (settings preview)
+    value_options:
+    - "no"
+    - "yes"

--- a/steps/bitrise-step-code-signing-setting-patch/step-info.yml
+++ b/steps/bitrise-step-code-signing-setting-patch/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4354)

Update version with minor changes.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.