### PR TITLE
azure-devops-pr-status 1.0.0

### DIFF
--- a/steps/azure-devops-pr-status/1.0.0/step.yml
+++ b/steps/azure-devops-pr-status/1.0.0/step.yml
@@ -1,0 +1,131 @@
+title: Azure DevOps PR status
+summary: |
+  Update pull request status for Azure DevOps repositories
+description: |
+  Update pull request status for Azure DevOps repositories.
+  This step always runs, no matter if build succeeded or failed.
+website: https://github.com/omidnowrouzi-p2/bitrise-step-azure-devops-pr-status
+source_code_url: https://github.com/omidnowrouzi-p2/bitrise-step-azure-devops-pr-status
+support_url: https://github.com/omidnowrouzi-p2/bitrise-step-azure-devops-pr-status/issues
+published_at: 2025-01-28T10:03:51.956828-06:00
+source:
+  git: https://github.com/omidnowrouzi-p2/bitrise-step-azure-devops-pr-status.git
+  commit: 4dbc411184546cc8659cca83ee254e2a46d84576
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+run_if: not (enveq "BITRISE_GIT_COMMIT" "")
+inputs:
+- devops_user: $AZURE_DEVOPS_USER
+  opts:
+    description: |
+      Azure DevOps user name.
+
+      Can also be taken from secret `AZURE_DEVOPS_USER`. Cannot be empty.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: Azure DevOps user name
+- devops_pat: $AZURE_DEVOPS_PAT
+  opts:
+    description: |
+      Azure DevOps Personal Access Token.
+
+      Can also be taken from secret `AZURE_DEVOPS_PAT`. Cannot be empty.
+    is_expand: true
+    is_required: true
+    is_sensitive: true
+    title: Azure DevOps Personal Access Token
+- devops_organization: $AZURE_DEVOPS_ORGANIZATION
+  opts:
+    description: |
+      Azure DevOps organization.
+
+      Can also be taken from env var `AZURE_DEVOPS_ORGANIZATION`. Cannot be empty.
+    is_expand: true
+    is_required: true
+    title: Azure DevOps organization
+- devops_project: $AZURE_DEVOPS_PROJECT
+  opts:
+    description: |
+      Azure DevOps project.
+
+      Can also be taken from env var `AZURE_DEVOPS_PROJECT`. Cannot be empty.
+    is_expand: true
+    is_required: true
+    title: Azure DevOps project
+- devops_repository_id: $AZURE_DEVOPS_REPOSITORY_ID
+  opts:
+    description: |
+      Azure DevOps repository ID.
+
+      Can also be taken from env var `AZURE_DEVOPS_REPOSITORY_ID`. Cannot be empty.
+    is_expand: true
+    is_required: true
+    title: Azure DevOps repository ID
+- devops_pr_state: auto
+  opts:
+    description: |
+      Status to set on pr.
+
+      Possible values are `auto`, `error`, `failed`, `notApplicable`, `notSet`, `pending`, `succeeded`.
+      If set to `auto` then step will automatically set `succeeded` or `failed` based on build status.
+    is_expand: true
+    is_required: true
+    title: Pull Request status
+    value_options:
+    - auto
+    - pending
+    - succeeded
+    - failed
+    - error
+    - notSet
+    - notApplicable
+- devops_description: ""
+  opts:
+    description: "Status description.\n\nTypically describes current state of the
+      status. \nIf no value provided, then will be set to `$BITRISE_APP_TITLE build
+      #$BITRISE_BUILD_NUMBER $state`.\n"
+    is_expand: true
+    is_required: false
+    title: Pull Request status description
+- devops_target_url: $BITRISE_BUILD_URL
+  opts:
+    description: |
+      URL with status details.
+
+      This URL will be opened when status description is clicked from Azure DevOps. Cannot be empty
+    is_expand: true
+    is_required: true
+    title: Target URL
+- devops_context_name: build/$BITRISE_APP_TITLE
+  opts:
+    description: |
+      Name identifier of the status.
+
+      Typically name of the build pipeline/configuration. Cannot be empty.
+    is_expand: true
+    is_required: true
+    title: Name identifier
+- devops_context_genre: continuous-integration
+  opts:
+    description: |
+      Genre of the status.
+
+      Typically name of the service/tool generating the status. Can be empty.
+    is_expand: true
+    is_required: false
+    title: Status genre

--- a/steps/azure-devops-pr-status/step-info.yml
+++ b/steps/azure-devops-pr-status/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4370)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.