### PR TITLE
scan-with-appsweep 3.0.0

### DIFF
--- a/steps/scan-with-appsweep/3.0.0/step.yml
+++ b/steps/scan-with-appsweep/3.0.0/step.yml
@@ -1,0 +1,88 @@
+title: AppSweep Mobile Security Testing
+summary: Scan your app using Guardsquare's mobile application security testing tool
+  AppSweep
+description: "The build of your Android or iOS app is automatically uploaded to [AppSweep](https://appsweep.guardsquare.com)
+  for scanning. \n\nAppSweep is Guardsquare's free tool enabling developers to put
+  mobile security at the forefront of app development. AppSweep helps you identify
+  and fix security issues in your code and dependencies with actionable recommendations
+  and insights that will help you build more secure mobile apps."
+website: https://www.guardsquare.com/appsweep-mobile-application-security-testing
+source_code_url: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep
+support_url: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep/issues
+published_at: 2025-02-04T08:40:54.61564+01:00
+source:
+  git: https://github.com/Guardsquare/bitrise-step-scan-with-appsweep.git
+  commit: c7e0e6f16b8876d05ddfb0680b1041cab5f3dcb2
+host_os_tags:
+- osx-10.10
+- ubuntu-16.04
+project_type_tags:
+- android
+- ios
+type_tags:
+- test
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: true
+inputs:
+- appsweep_api_key: $APPSWEEP_API_KEY
+  opts:
+    description: |
+      An `APPSWEEP_API_KEY` must be set to allow scanning of the app inside an AppSweep project. You can generate it in the API Keys section of your app settings inside AppSweep.
+    is_required: true
+    is_sensitive: true
+    title: AppSweep API key
+- commit_hash: $GIT_CLONE_COMMIT_HASH
+  opts:
+    description: |
+      The commit for this build. This commit will be associated with the app scan.
+    title: Git commit hash
+- ios_archive_path: $BITRISE_XCARCHIVE_PATH
+  opts:
+    category: iOS
+    description: |
+      AppSweep works with both, an IPA file or an xcarchive directory. This has to be set if you want to analyze iOS builds.
+    is_required: false
+    title: The path of the iOS archive
+- ios_dsyms_dir_path: $BITRISE_DSYM_DIR_PATH
+  opts:
+    category: iOS
+    description: |
+      Should the archive not include debug symbols, it is possible to pass in the path to the dSYM directory explicitly. Lacking debug symbols prevents AppSweep from performing an in-depth analysis.
+    is_required: false
+    title: The path of the dSYM directory.
+- android_app_path: $BITRISE_APK_PATH
+  opts:
+    description: |
+      Path name to the built app. Can be an Android apk / aab.
+    is_required: false
+    title: The path of the Android app
+- android_mappingfile_path: null
+  opts:
+    category: Android
+    description: |
+      Path to the obfuscation mapping file. E.g., ./app/build/outputs/mapping/debug/mapping.txt
+    is_required: false
+    title: The path to the obfuscation mapping file
+- android_project_location: $PROJECT_LOCATION
+  opts:
+    category: Android
+    description: |
+      Set this to the location of your project inside your repository. Inside this directory, the build file should be `./app/build.gradle` and `gradlew` should be directly in the `project_location`.
+    is_required: false
+    title: Project file path
+outputs:
+- APPSWEEP_UPLOAD_URL: null
+  opts:
+    description: |
+      This URL of a particular scan is generated during the execution of this step, the results of the scan can be accessed in AppSweep directly via this URL.
+    summary: Direct link to the scan results on AppSweep website
+    title: AppSweep upload URL


### PR DESCRIPTION
Version 3.0.0 uses the `guardsquare` CLI for both Android and iOS, requiring no additional setup for most scenarios. Previously, only the iOS step was handled by the CLI.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x]  I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
