### PR TITLE
stamp-appicon-with-version-number: mark duplicate step as deprecated

### DIFF
--- a/steps/stamp-appicon-with-version-number/step-info.yml
+++ b/steps/stamp-appicon-with-version-number/step-info.yml
@@ -1,1 +1,3 @@
 maintainer: community
+deprecate_notes: This step is a duplicate of "bitrise-step-stamp-appicon-with-version-number". Please use that step ID instead.
+removal_date: 2025-09-31


### PR DESCRIPTION
Discussion: https://github.com/ollitapa/bitrise-step-stamp-appicon-with-version-number/issues/5