### PR TITLE
version-pre-release-info: mark duplicate step as deprecated

### DIFF
--- a/steps/version-pre-release-info/step-info.yml
+++ b/steps/version-pre-release-info/step-info.yml
@@ -1,1 +1,3 @@
 maintainer: community
+removal_date: 2025-09-31
+deprecate_notes: This step is a duplicate of "bitrise-step-version-pre-release-info". Please use that step ID instead.


### PR DESCRIPTION
Usage wise `bitrise-version-pre-release-info` is more common, but both steps have users to this day.

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/3a4c9986-f734-49ae-af7a-6093147ad8c6" />
