### PR TITLE
bitrise-step-multikey-restore-cache 0.1.0

### DIFF
--- a/steps/bitrise-step-multikey-restore-cache/0.1.0/step.yml
+++ b/steps/bitrise-step-multikey-restore-cache/0.1.0/step.yml
@@ -1,0 +1,138 @@
+title: Multikey Restore Cache
+summary: Restores build cache using a cache keys. This Step needs to be used in combination
+  with **Multikey Save Cache** or **Save Cache**.
+description: |
+  Restores items from the cache based on a list of keys.
+
+  The format of the keys input is the following:
+  ```
+  KEY1 || KEY1_ALTERNATIVE1 || KEY1_ALTERNATIVE2
+  KEY2
+  KEY3 || KEY3_ALTERNATIVE1
+  ```
+  The number of keys and paths for each are limited to a number of 10. Commas (`,`) and equal signs (`=`) are not allowed in keys. See templates that can be used in the keys below.
+
+  Example (somewhat artificial):
+  ```
+  multikey_0 || multikey_0_fallback
+  multikey_1
+  multikey_2 || multikey_2_fallback
+  ```
+
+  This Step needs to be used in combination with **Multikey Save Cache** or **Save Cache**.
+
+  #### About key-based caching
+
+  Key-based caching is a concept where cache archives are saved and restored using a unique cache key. One Bitrise project can have multiple cache archives stored simultaneously, and the **Multikey Restore Cache** step downloads a cache archive associated with the key provided as a Step input.
+
+  Caches can become outdated across builds when something changes in the project (for example, a dependency gets upgraded to a new version). In this case, a new (unique) cache key is needed to save the new cache contents. This is possible if the cache key is dynamic and changes based on the project state (for example, a checksum of the dependency lockfile is part of the cache key). If you use the same dynamic cache key when restoring the cache, the Step will download the most relevant cache archive available.
+
+  Key-based caching is platform-agnostic and can be used to cache anything by carefully selecting the cache key and the files/folders to include in the cache.
+
+  #### Templates
+
+  The Step requires a string key to use when downloading a cache archive. In order to always download the most relevant cache archive for each build, the cache key input can contain template elements. The Step evaluates the key template at runtime and the final key value can change based on the build environment or files in the repo.
+
+  The following variables are supported in cache keys input:
+
+  - `cache-key-{{ .Branch }}`: Current git branch the build runs on
+  - `cache-key-{{ .CommitHash }}`: SHA-256 hash of the git commit the build runs on
+  - `cache-key-{{ .Workflow }}`: Current Bitrise workflow name (eg. `primary`)
+  - `{{ .Arch }}-cache-key`: Current CPU architecture (`amd64` or `arm64`)
+  - `{{ .OS }}-cache-key`: Current operating system (`linux` or `darwin`)
+
+  Functions available in a template:
+
+  `checksum`: This function takes one or more file paths and computes the SHA256 [checksum](https://en.wikipedia.org/wiki/Checksum) of the file contents. This is useful for creating unique cache keys based on files that describe content to cache.
+
+  Examples of using `checksum`:
+  - `cache-key-{{ checksum "package-lock.json" }}`
+  - `cache-key-{{ checksum "**/Package.resolved" }}`
+  - `cache-key-{{ checksum "**/*.gradle*" "gradle.properties" }}`
+
+  `getenv`: This function returns the value of an environment variable or an empty string if the variable is not defined.
+
+  Examples of `getenv`:
+  - `cache-key-{{ getenv "PR" }}`
+  - `cache-key-{{ getenv "BITRISEIO_PIPELINE_ID" }}`
+
+  #### Key matching and fallback keys
+
+  The most straightforward use case is that a cache archive is downloaded and restored if the provided key matches a cache archive uploaded previously using the Save Cache Step. Stored cache archives are scoped to the Bitrise project. Builds can restore caches saved by any previous Workflow run on any Bitrise Stack.
+
+  It's possible to define more than one key in the cache keys input. You can specify additional alternative keys by appending them with `||` in the same line as the key. The list is in priority order, so the Step will first try to find a match for the first key you provided, and if there is no cache stored for the key, it will move on to find a match for the second key (and so on).
+
+  In addition to listing multiple keys, each key can be a prefix of a saved cache key and still get a matching cache archive. For example, the key `my-cache-` can match an existing archive saved with the key `my-cache-a6a102ff`.
+
+  We recommend configuring the keys in a way that the first key is an exact match to a checksum key, and to use a more generic prefix key as a fallback:
+
+  ```
+  inputs:
+    key: |
+      multikey_0 || multikey_0_fallback
+      multikey
+  ```
+
+  #### Related steps
+
+  [Save cache](https://github.com/bitrise-steplib/bitrise-step-save-cache/)
+website: https://github.com/bitrise-steplib/bitrise-step-restore-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-restore-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-restore-cache/issues
+published_at: 2025-08-05T14:48:22.923282+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-multikey-restore-cache.git
+  commit: 246caa5e66015b3d5dbc08dd224bc290c2cbb0d8
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-restore-cache
+deps:
+  brew:
+  - name: zstd
+  apt_get:
+  - name: zstd
+is_skippable: true
+run_if: .IsCI
+inputs:
+- keys: null
+  opts:
+    description: |-
+      Keys used for restoring a cache archive. One cache key per line in priority order.
+
+      The key supports template elements for creating dynamic cache keys. These dynamic keys change the final key value based on the build environment or files in the repo in order to create new cache archives. See the Step description for more details and examples.
+
+      The maximum length of a key is 512 characters (longer keys get truncated) and you can list at most 8 keys using this input. Commas (`,`) are not allowed in keys.
+    is_required: true
+    summary: Keys used for restoring a cache archive. The key can contain template
+      elements.
+    title: Cache keys
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting.
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"
+- opts:
+    category: Debugging
+    description: |-
+      Number of retries to attempt when downloading a cache archive fails.
+
+      The value 0 means no retries are attempted.
+    is_required: true
+    summary: Number of retries to attempt when downloading a cache archive fails.
+    title: Number of retries
+  retries: 3
+outputs:
+- BITRISE_CACHE_HIT: null
+  opts:
+    description: |-
+      Indicates if a cache entry was restored. Possible values:
+
+      - `exact`: Exact cache hit for the first requested cache key
+      - `partial`: Cache hit for a key other than the first
+      - `false` No cache hit, nothing was restored
+    title: Cache hit

--- a/steps/bitrise-step-multikey-restore-cache/step-info.yml
+++ b/steps/bitrise-step-multikey-restore-cache/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4541)

https://github.com/bitrise-steplib/bitrise-step-multikey-restore-cache/releases/0.1.0



**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.