### PR TITLE
activate-build-cache-for-xcode 0.0.2

### DIFF
--- a/steps/activate-build-cache-for-xcode/0.0.2/step.yml
+++ b/steps/activate-build-cache-for-xcode/0.0.2/step.yml
@@ -1,0 +1,42 @@
+title: Build Cache for Xcode
+summary: Activates Bitrise Remote Build Cache add-on for subsequent Xcode builds in
+  the workflow
+description: |
+  This Step enables Bitrise's Build Cache Add‑On for Xcode by configuring the environment with the Build Cache CLI.
+
+  After this Step runs, Xcode builds invoked via xcodebuild in subsequent workflow steps will automatically read from the remote cache and push new entries when applicable.
+
+  The Step adds an alias to ~/.zshrc and ~/.bashrc so the wrapper is available in all following steps; from that point all xcodebuild calls are wrapped to enable compilation caching.
+  Analytical data (command, duration, cache information, environment) is collected and sent to Bitrise and is available on the Build cache page: https://app.bitrise.io/build-cache
+website: https://github.com/bitrise-steplib/bitrise-step-activate-xcode-remote-cache
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-xcode-remote-cache
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-xcode-remote-cache
+published_at: 2025-09-16T09:58:03.433296+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-build-cache-for-xcode.git
+  commit: 4bac0e037cb2a91a0d19626f3302cf731600f968
+type_tags:
+- utility
+toolkit:
+  bash:
+    entry_file: step.sh
+is_skippable: true
+run_if: .IsCI
+inputs:
+- opts:
+    is_required: true
+    summary: Enable logging additional information for troubleshooting
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"
+- opts:
+    is_required: true
+    summary: Whether the build can not only read, but write new entries to the remote
+      cache
+    title: Push new cache entries
+    value_options:
+    - "true"
+    - "false"
+  push: "true"


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
