### PR TITLE
activate-build-cache-for-react-native 0.2.0

### DIFF
--- a/steps/activate-build-cache-for-react-native/0.2.0/step.yml
+++ b/steps/activate-build-cache-for-react-native/0.2.0/step.yml
@@ -1,0 +1,71 @@
+title: Build Cache for React Native
+summary: Activates Bitrise Build Cache features for React Native projects
+description: |
+  This Step activates Bitrise Build Cache for all build systems used in a React Native project.
+
+  After this Step executes,
+  - enabling Xcode cache will result in: iOS builds will use the Bitrise Build Cache for Xcode via Xcelerate, with a background proxy started automatically.
+  - enabling Gradle cache will result in: Android Gradle builds will automatically read from and push entries to the remote cache. C++ native modules will also be compiled using ccache, with a background storage helper started automatically.
+
+website: https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features
+support_url: https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features
+published_at: 2026-04-15T07:28:02.846206874Z
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features.git
+  commit: 8f6a31e16cfbd94c5256c2687c2b8720b77e7c25
+
+project_type_tags:
+- react-native
+- ios
+- android
+type_tags:
+- utility
+
+run_if: .IsCI
+is_skippable: true
+
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-activate-react-native-features
+
+inputs:
+# -------------------------------------------------------------------------------
+# Xcode cache
+# -------------------------------------------------------------------------------
+- xcode_cache_enabled: "true"
+  opts:
+    title: Enable Xcode cache
+    summary: Enables Bitrise Build Cache for Xcode using Xcelerate
+    is_required: true
+    value_options:
+    - "true"
+    - "false"
+    description: |-
+      Enables Bitrise Build Cache for Xcode. When enabled, activates Xcelerate and starts the Xcelerate proxy in the background.
+
+# -------------------------------------------------------------------------------
+# Gradle cache
+# -------------------------------------------------------------------------------
+- gradle_cache_enabled: "true"
+  opts:
+    title: Enable Gradle cache
+    summary: Enables Bitrise Build Cache for Gradle
+    is_required: true
+    value_options:
+    - "true"
+    - "false"
+    description: |-
+      Enables Bitrise Build Cache for Gradle. When enabled, activates Gradle cache with analytics and remote cache plugins.
+
+# -------------------------------------------------------------------------------
+# Debugging
+# -------------------------------------------------------------------------------
+- verbose: "false"
+  opts:
+    title: Verbose logging
+    summary: Enable logging additional information for troubleshooting
+    is_required: true
+    value_options:
+    - "true"
+    - "false"


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4826)

https://github.com/bitrise-steplib/bitrise-step-activate-react-native-features/releases/0.2.0

Manual steplib submission for activate-build-cache-for-react-native 0.2.0 (auto-PR had merge conflict).