### PR TITLE
Add bitrise-step-semaloop-submit-build 0.1.0

### DIFF
--- a/steps/bitrise-step-semaloop-submit-build/0.1.0/step.yml
+++ b/steps/bitrise-step-semaloop-submit-build/0.1.0/step.yml
@@ -1,0 +1,42 @@
+title: Semaloop Submit Build
+summary: |
+  Submits an iOS build to Semaloop and enqueues tests.
+description: |
+  Submits an iOS build to Semaloop and enqueues tests.
+website: https://github.com/semaloop/bitrise-step-semaloop-submit-build
+source_code_url: https://github.com/semaloop/bitrise-step-semaloop-submit-build
+support_url: https://github.com/semaloop/bitrise-step-semaloop-submit-build/issues
+published_at: 2026-04-30T11:11:34.438628+01:00
+source:
+  git: https://github.com/semaloop/bitrise-step-semaloop-submit-build.git
+  commit: 0954ecc7ef1948e7c1ca29aa415f9c08752b40ab
+project_type_tags:
+- ios
+type_tags:
+- deploy
+toolkit:
+  bash:
+    entry_file: step.sh
+inputs:
+- api_key: $SEMALOOP_API_KEY
+  opts:
+    is_required: true
+    is_sensitive: true
+    title: Semaloop API key
+- app_path: $BITRISE_APP_PATH
+  opts:
+    is_required: false
+    summary: Direct path to a simulator `.app` bundle. Takes precedence over `test_bundle_path`.
+    title: Simulator .app path
+- opts:
+    is_required: false
+    summary: Directory to search for a simulator `.app` bundle (e.g. the `BITRISE_TEST_BUNDLE_PATH`
+      output of the Xcode Build for Testing step). Ignored if `app_path` is set.
+    title: Test bundle directory
+  test_bundle_path: $BITRISE_TEST_BUNDLE_PATH
+- ipa_path: $BITRISE_IPA_PATH
+  opts:
+    is_required: false
+    summary: Path to the signed .ipa file. Produced by the Xcode Archive & Export
+      step.
+    title: Device .ipa path

--- a/steps/bitrise-step-semaloop-submit-build/step-info.yml
+++ b/steps/bitrise-step-semaloop-submit-build/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4871)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.