### PR TITLE
Deprecated App Center and codepush steps

### DIFF
--- a/steps/appcenter-apk-upload/step-info.yml
+++ b/steps/appcenter-apk-upload/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: community
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-codepush-release-react-native/step-info.yml
+++ b/steps/appcenter-codepush-release-react-native/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: community
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-deploy-android/step-info.yml
+++ b/steps/appcenter-deploy-android/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: bitrise
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-deploy-ios/step-info.yml
+++ b/steps/appcenter-deploy-ios/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: bitrise
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-dsym-upload/step-info.yml
+++ b/steps/appcenter-dsym-upload/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: community
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-ipa-upload/step-info.yml
+++ b/steps/appcenter-ipa-upload/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: community
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).

--- a/steps/appcenter-test/step-info.yml
+++ b/steps/appcenter-test/step-info.yml
@@ -1,1 +1,6 @@
 maintainer: bitrise
+removal_date: "2026-08-08"
+deprecate_notes: |
+  App Center is deprecated.
+
+  We recommend to use [Bitrise Release Management](https://docs.bitrise.io/en/release-management.html) and [Bitrise CodePush](https://docs.bitrise.io/en/release-management/codepush/about-codepush.html).


### PR DESCRIPTION
### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] __I will not move an already shared step version's tag to another commit__
- [ ] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [ ] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
