### PR TITLE
hexsign-fetch-signing-material 0.1.0

### DIFF
--- a/steps/hexsign-fetch-signing-material/0.1.0/step.yml
+++ b/steps/hexsign-fetch-signing-material/0.1.0/step.yml
@@ -1,0 +1,124 @@
+title: HexSign — Fetch Signing Material
+summary: Download Apple signing certificates and provisioning profiles from HexSign.
+description: |-
+  Downloads Apple signing certificates (`.p12` + password) and/or provisioning profiles
+  (`.mobileprovision`) from your [HexSign](https://hexsign.io) account, ready for
+  consumption by `certificate-and-profile-installer`, `xcode-archive`, or `fastlane`.
+
+  At least one of `certificate_id` or `profile_id` must be provided — both are optional
+  individually, so this single step covers fetch-cert-only, fetch-profile-only, and
+  fetch-both flows.
+
+  The `hexsign` CLI binary is downloaded from the official GitHub releases on first run
+  and verified against the release's `checksums.txt`. Set `cli_version` to pin a specific
+  CLI release; the default (`latest`) tracks the most recent stable.
+
+  Service credentials are provisioned per-organization in the HexSign dashboard under
+  Settings → CLI Tokens. Pass them via Bitrise secrets, not in the workflow YAML.
+website: https://github.com/hexsign/bitrise-step-hexsign
+source_code_url: https://github.com/hexsign/bitrise-step-hexsign
+support_url: https://github.com/hexsign/bitrise-step-hexsign/issues
+published_at: 2026-05-12T21:23:56.121943+10:00
+source:
+  git: https://github.com/hexsign/bitrise-step-hexsign.git
+  commit: 2b93208ce302bcbd81567dc4a980e2f829858f8b
+asset_urls:
+  icon.png: https://raw.githubusercontent.com/hexsign/bitrise-step-hexsign/main/assets/logo.png
+  icon.svg: https://raw.githubusercontent.com/hexsign/bitrise-step-hexsign/main/assets/logo.svg
+project_type_tags:
+- ios
+- macos
+- flutter
+- react-native
+- cordova
+- ionic
+type_tags:
+- installer
+- code-sign
+toolkit:
+  bash:
+    entry_file: step.sh
+deps:
+  brew:
+  - name: curl
+  - name: jq
+is_requires_admin_user: false
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- certificate_id: ""
+  opts:
+    description: |
+      The HexSign certificate ID to download. Leave empty to skip certificate download.
+      At least one of `certificate_id` or `profile_id` must be provided.
+    is_required: false
+    summary: HexSign certificate ID to download (optional).
+    title: Certificate ID
+- opts:
+    description: |
+      The HexSign provisioning profile ID to download. Leave empty to skip profile download.
+      At least one of `certificate_id` or `profile_id` must be provided.
+    is_required: false
+    summary: HexSign provisioning profile ID to download (optional).
+    title: Provisioning Profile ID
+  profile_id: ""
+- client_id: $HEXSIGN_CLIENT_ID
+  opts:
+    description: |
+      OAuth2 client ID for a service credential. Create one in the HexSign dashboard
+      under Settings → CLI Tokens.
+    is_required: true
+    is_sensitive: true
+    summary: Service credential client ID.
+    title: HexSign Client ID
+- client_secret: $HEXSIGN_CLIENT_SECRET
+  opts:
+    description: |
+      OAuth2 client secret for a service credential. Pair with `client_id` from the
+      same dashboard-issued token. Always pass via a Bitrise secret env var.
+    is_required: true
+    is_sensitive: true
+    summary: Service credential client secret.
+    title: HexSign Client Secret
+- opts:
+    description: |
+      Override the default scopes (`hexsign-api/read hexsign-api/write`). Leave empty
+      for the default. Read-only operations need only `hexsign-api/read`.
+    is_required: false
+    summary: Space-separated OAuth scopes (optional).
+    title: OAuth Scopes
+  scopes: ""
+- opts:
+    description: |
+      Where to write the `.p12`, `.password`, and `.mobileprovision` files.
+      Defaults to `$BITRISE_DEPLOY_DIR` so artifacts are picked up by the
+      Deploy to Bitrise.io step.
+    is_required: true
+    summary: Directory to write downloaded files into.
+    title: Output Directory
+  output_dir: $BITRISE_DEPLOY_DIR
+- cli_version: latest
+  opts:
+    description: |
+      Pin a specific [hexsign-cli release](https://github.com/hexsign/hexsign-cli/releases),
+      or leave as `latest` to always pull the most recent.
+    is_required: true
+    summary: CLI release tag to use (e.g. v0.2.1) or `latest`.
+    title: HexSign CLI Version
+outputs:
+- HEXSIGN_CERTIFICATE_PATH: null
+  opts:
+    summary: Absolute path to the downloaded certificate, or empty if no certificate
+      was fetched.
+    title: Path to the downloaded .p12 file
+- HEXSIGN_CERTIFICATE_PASSWORD_PATH: null
+  opts:
+    summary: Absolute path to the certificate's password file (the file's contents
+      are the password).
+    title: Path to the .password file
+- HEXSIGN_PROFILE_PATH: null
+  opts:
+    summary: Absolute path to the downloaded provisioning profile, or empty if no
+      profile was fetched.
+    title: Path to the downloaded .mobileprovision file

--- a/steps/hexsign-fetch-signing-material/step-info.yml
+++ b/steps/hexsign-fetch-signing-material/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: community


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=4908)

### What to do if the build fails?

At the moment contributors do not have access to the CI workflow triggered by StepLib PRs. In case of a failed build, we ask for your patience. Maintainers of Bitrise Steplib will sort it out for you or inform you if any further action is needed.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] __I will not move an already shared step version's tag to another commit__
- [x] I read the [Step Development Guideline](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md)
- [x] I have a test for my Step, which can be run with `bitrise run test` (in the step's repository)
- [x] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [x] I read and accept the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)


**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.