### PR TITLE
react-native-fingerprint-0.1.0

### DIFF
--- a/steps/react-native-fingerprint/0.1.0/step.yml
+++ b/steps/react-native-fingerprint/0.1.0/step.yml
@@ -1,0 +1,132 @@
+title: Fingerprint React Native build inputs
+summary: Fingerprints your native inputs and exports BUNDLE_HASH_STRING so caches
+  skip native rebuilds.
+description: |
+  Computes a deterministic SHA-256 **fingerprint** of the inputs that determine your native build and exports it as **`BUNDLE_HASH_STRING`**, so you can key `restore-cache` / `save-cache` off it and skip the expensive native build when only JavaScript changed.
+
+  It hashes the files and folders in `path_list` (folders are hashed recursively), while excluding anything matched by `ignore_path_list`. The default covers the common React Native native inputs — JS lockfiles, `app.json` / `app.config.js`, `patch-package` patches, and the `ios/` and `android/` native projects. It deliberately does not hash your JavaScript source, so a JS-only change reuses the cached native build.
+
+  `ignore_path_list` is important for **correctness**, not just speed: it excludes build outputs that change every run (`ios/Pods`, `android/build`, …) and machine-specific files that would otherwise make the fingerprint differ between CI and local (`android/local.properties`, Xcode user state, …).
+
+  Use `BUNDLE_HASH_STRING` as the key for `restore-cache` / `save-cache`, then gate the native/bundle build on restore-cache's `BITRISE_CACHE_HIT` output. On a hit, repack the new JS bundle into the cached app and re-sign.
+
+  The step is skippable: if fingerprinting can't produce a key (or fails), it exports an **empty** `BUNDLE_HASH_STRING` — a cache miss that safely forces a rebuild — rather than blocking your pipeline.
+
+  **Capture every native input.** The fingerprint decides whether a previously compiled native app can be reused. If `path_list` / `ignore_path_list` omit an input that affects the native build (a native module dir, a config plugin, an extra lockfile), a native change may not move the key and you could repack onto a **stale binary**. Extend `path_list` for your project when needed.
+
+  This is a lightweight, do-it-yourself pattern built on free Bitrise cache steps. For a fully managed, compilation-level remote cache across Gradle, Xcode (LLVM CAS) and C++, see Bitrise Build Cache for React Native: https://bitrise.io/platform/build-cache/react-native
+website: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint
+support_url: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint/issues
+published_at: 2026-08-12T15:08:47.997366+02:00
+source:
+  git: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint.git
+  commit: 0494096dde187718bb7472a226fa4fa175fdbcea
+project_type_tags:
+- react-native
+type_tags:
+- utility
+toolkit:
+  go:
+    package_name: github.com/bitrise-steplib/bitrise-step-react-native-fingerprint
+is_always_run: false
+is_skippable: true
+inputs:
+- opts:
+    description: |
+      Root that path_list and ignore_path_list are resolved against.
+
+      The React Native project root. Entries are interpreted relative to this directory, and the fingerprint uses each file's path relative to it, so the result is independent of where the project is checked out.
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Root that path_list and ignore_path_list are resolved against.
+    title: Project directory
+  project_dir: .
+- opts:
+    description: |
+      Newline-separated files and folders whose contents determine the key.
+
+      One entry per line, relative to `project_dir`:
+      - a **file** — e.g. `package.json`
+      - a **folder** — trailing slash, e.g. `ios/` (hashed recursively)
+      - a **glob** — a `*` / `**` doublestar pattern, e.g. `android/**/*.gradle`
+
+      The trailing slash is a readability convention — the step detects each entry's type automatically, so `ios` and `ios/` behave the same. Missing entries are skipped with a warning. Blank lines and lines starting with `#` are ignored.
+
+      The default covers common React Native native inputs; extend it for your project (custom native module directories, additional lockfiles, `Gemfile.lock`, etc.).
+    is_expand: true
+    is_required: true
+    is_sensitive: false
+    summary: Newline-separated files and folders whose contents determine the key.
+    title: Paths to fingerprint
+  path_list: |-
+    package.json
+    package-lock.json
+    yarn.lock
+    pnpm-lock.yaml
+    app.json
+    app.config.js
+    patches/
+    ios/
+    android/
+- ignore_path_list: |-
+    ios/Pods
+    ios/build
+    ios/DerivedData
+    ios/.xcode.env.local
+    android/build
+    android/app/build
+    android/.gradle
+    android/app/.cxx
+    android/local.properties
+    **/xcuserdata
+    **/*.xcuserstate
+    **/*.log
+    **/.DS_Store
+    node_modules
+    .git
+  opts:
+    description: |
+      Newline-separated paths/globs to exclude from the fingerprint.
+
+      Entries (relative to `project_dir`) matched as directory prefixes or `**` doublestar globs. This list matters for correctness: it excludes per-build outputs (`ios/Pods`, `android/build`, …) and machine-specific files (`android/local.properties`, Xcode user state) that would otherwise make the fingerprint differ between machines and prevent cache hits. Blank lines and `#` comments are ignored.
+    is_expand: true
+    is_required: false
+    is_sensitive: false
+    summary: Newline-separated paths/globs to exclude from the fingerprint.
+    title: Ignore paths
+- key_prefix: null
+  opts:
+    description: |
+      Optional namespace prepended to the fingerprint (joined with a hyphen).
+
+      When set, it is prepended to `BUNDLE_HASH_STRING` (e.g. `ios-<fingerprint>`), for namespacing the cache key per platform or workflow so different builds don't collide.
+    is_expand: true
+    is_required: false
+    is_sensitive: false
+    summary: Optional namespace prepended to the fingerprint (joined with a hyphen).
+    title: Cache key prefix
+- opts:
+    category: Debug
+    description: |
+      Log the files that contribute to the fingerprint.
+
+      Prints (at debug level) each file included in the fingerprint — useful for confirming that path_list and ignore_path_list match what you expect.
+    is_required: true
+    is_sensitive: false
+    summary: Log the files that contribute to the fingerprint.
+    title: Verbose logging
+    value_options:
+    - "true"
+    - "false"
+  verbose: "false"
+outputs:
+- BUNDLE_HASH_STRING: null
+  opts:
+    description: |-
+      The computed fingerprint, prefixed with key_prefix if set.
+
+      **Empty** when no inputs matched — treat an empty value as a cache miss and rebuild the app. Use it as the key for `restore-cache` / `save-cache` steps; gate the build on restore-cache's `BITRISE_CACHE_HIT` output.
+    summary: The computed fingerprint, prefixed with key_prefix if set.
+    title: Bundle hash

--- a/steps/react-native-fingerprint/step-info.yml
+++ b/steps/react-native-fingerprint/step-info.yml
@@ -1,0 +1,1 @@
+maintainer: bitrise


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=5104)

https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint/releases/0.1.0

New step: **React Native Fingerprint** (`react-native-fingerprint`) — first version, 0.1.0.

Computes a deterministic SHA-256 fingerprint of the inputs that determine a React Native native build and exports it as `BUNDLE_HASH_STRING`, so `restore-cache` / `save-cache` can skip the native rebuild when only JavaScript changed.

- Step repository: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint
- Release: https://github.com/bitrise-steplib/bitrise-step-react-native-fingerprint/releases/tag/0.1.0
- Official conversion of the community step, tracked in STEP-2489; ownership goes to the ACI team after release
- `step-info.yml` with `maintainer: bitrise` included
- Submitted manually via `stepman share` (first release of a new step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**New Step**
Thank you for the new Step share! The CI check might will fail due to our extended validation engine. Nothing to worry about yet, we will get back to you shortly.