### PR TITLE
appdome-build-2secure-android 3.7.0

### DIFF
--- a/steps/appdome-build-2secure-android/3.7.0/step.yml
+++ b/steps/appdome-build-2secure-android/3.7.0/step.yml
@@ -1,0 +1,216 @@
+title: Appdome-Build-2Secure for Android
+summary: |
+  Builds a mobile app using Appdome's platform
+description: |
+  Integration that allows activating security and app protection features, building and signing mobile apps using Appdome's API. For details see: https://www.appdome.com/how-to/appsec-release-orchestration/mobile-appsec-cicd/use-appdome-build-2secure-step-for-bitrise
+website: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+source_code_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android
+support_url: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android/issues
+published_at: 2026-08-25T14:17:51.292582+03:00
+source:
+  git: https://github.com/Appdome/bitrise-step-appdome-build-2secure-android.git
+  commit: e645e58608df8234d41ec27821b67a07fbd57f13
+project_type_tags:
+- android
+type_tags:
+- build
+- code-sign
+toolkit:
+  bash:
+    entry_file: step_init.sh
+deps:
+  brew:
+  - name: curl
+  apt_get:
+  - name: curl
+inputs:
+- app_location: null
+  opts:
+    is_required: true
+    summary: URL to app file (apk/aab) or an EnvVar representing its path (i.e. $BITRISE_APK_PATH
+      or $BITRISE_AAB_PATH)
+    title: App file URL or EnvVar
+- opts:
+    is_required: false
+    summary: Output app file name. The file extension (aab/apk) will be the same as
+      the original app. If not specified, the default output file will be same as
+      the original app but with Appdome_ prefix.
+    title: Output file name (without extension)
+  output_filename: null
+- fusion_set_id: null
+  opts:
+    is_required: true
+    title: Fusion set ID
+- opts:
+    is_required: false
+    title: Team ID
+  team_id: null
+- opts:
+    description: App signing method
+    is_required: true
+    title: Signing Method
+    value_options:
+    - On-Appdome
+    - Private-Signing
+    - Auto-Dev-Signing
+  sign_method: On-Appdome
+- android_keystore_url_env: null
+  opts:
+    category: On-Appdome Signing
+    description: Variable name from Project settings → Code Signing (no $). E.g. BITRISEIO_ANDROID_KEYSTORE_4_URL.
+      Leave empty for default primary or _1 keystore.
+    is_required: false
+    summary: Bitrise Code Signing keystore URL variable; password, alias, and key
+      password env names are derived from it.
+    title: Keystore URL — env var name
+- multiple_trusted_signing_certs_path: null
+  opts:
+    category: Multiple Trusted Signing Certificates
+    description: 'Path to file containing multiple trusted signing certificates, or
+      an EnvVar representing its path (e.g. $MULTIPLE_TRUSTED_CERTS_PATH). Note: Multiple
+      Trusted Signing Certificates can''t work alongside ''Google Signing'' or ''Private/Auto-Dev-Signing''
+      categories.'
+    is_required: false
+    summary: Path to file containing multiple trusted signing certificates (or an
+      EnvVar representing the path)
+    title: Multiple Trusted Signing Certificates file path
+- gp_signing: "false"
+  opts:
+    category: Google Signing
+    description: Sign the app for Google Play? If 'true', requires $SIGN_FINGERPRINT
+      in the Secrets tab.
+    is_required: true
+    title: Google Play Signing
+    value_options:
+    - "true"
+    - "false"
+- google_fingerprint: $GOOGLE_SIGN_FINGERPRINT
+  opts:
+    category: Google Signing
+    description: Google Sign Fingerprint for Google Play singing, or its Secret variable
+      name.
+    is_required: false
+    title: Google Sign Fingerprint
+- fingerprint: $SIGN_FINGERPRINT
+  opts:
+    category: Private/Auto-Dev Signing
+    description: Sign Fingerprint (not for Google Play singing), or its Secret variable
+      name.
+    is_required: false
+    title: Sign Fingerprint
+- download_deobfuscation: "true"
+  opts:
+    category: Deobfuscation Options
+    description: Select 'true' to download Appdome deobfuscation mapping zip file
+      to the Artifacts section.
+    is_required: false
+    summary: Select 'true' to download Appdome deobfuscation mapping zip file to the
+      Artifacts section.
+    title: Download deobfuscation mapping file?
+    value_options:
+    - "true"
+    - "false"
+- crashlytics_app_id: null
+  opts:
+    category: Deobfuscation Options
+    description: Crashlytics App ID as appears in the Firebase account, for auto upload
+      Appdome deobfuscation mapping file.
+    is_required: false
+    title: Crashlytics App ID
+- datadog_api_key: null
+  opts:
+    category: Deobfuscation Options
+    description: Datadog API Key, for auto upload Appdome deobfuscation mapping file.
+    is_required: false
+    title: Datadog API Key
+- baseline_profile: null
+  opts:
+    category: Profiles
+    description: Baseline profile for the build (.zip with baseline_prof.txt). Accepts
+      absolute path (e.g. $BITRISE_SOURCE_DIR/...), an EnvVar representing the path,
+      or a URL the step will download from.
+    is_required: false
+    summary: Baseline profile .zip file (absolute path, EnvVar, or URL).
+    title: Baseline Profile file
+- opts:
+    category: Profiles
+    description: Startup profile for the build (.zip with baseline_prof.txt). Accepts
+      absolute path (e.g. $BITRISE_SOURCE_DIR/...), an EnvVar representing the path,
+      or a URL the step will download from.
+    is_required: false
+    summary: Startup profile .zip file (absolute path, EnvVar, or URL).
+    title: Startup Profile file
+  startup_profile: null
+- opts:
+    description: Select 'true' to create a Universal.apk file (applies to .aab app
+      types only).
+    is_required: false
+    title: Secondary Output
+    value_options:
+    - "true"
+    - "false"
+  secondary_output: "false"
+- build_logs: "false"
+  opts:
+    description: Build the app with Appdome's Diagnostic Logs
+    is_required: true
+    title: Build With Diagnostic Logs
+    value_options:
+    - "true"
+    - "false"
+- build_to_test: None
+  opts:
+    description: Select a device cloud vendor this build will be ready for testing
+      on. Select None for a production build or for a vendor not in the list.
+    is_required: true
+    title: Build to test Vendor
+    value_options:
+    - None
+    - AWS_device_farm
+    - Bitbar
+    - Browserstack
+    - Firebase
+    - Katalon
+    - Kobiton
+    - Lambdatest
+    - Perfecto
+    - Tosca
+    - Saucelabs
+- opts:
+    is_required: false
+    summary: File name of the workflow logs.
+    title: Workflow output logs file name
+  workflow_output_logs: null
+outputs:
+- APPDOME_SECURED_APK_PATH: null
+  opts:
+    description: |
+      Local path of the secured .apk file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .apk file
+    title: Secured .apk file path
+- APPDOME_SECURED_AAB_PATH: null
+  opts:
+    description: |
+      Local path of the secured .aab file. Available when 'Signing Method' set to 'On-Appdome' or 'Private-Signing'
+    summary: Local path of the secured .aab file
+    title: Secured .aab file path
+- APPDOME_SECURED_SO_PATH: null
+  opts:
+    description: |
+      Local path of the secured secondary output file (universal apk). Available if Secondary Output is set to 'true' and the original app is .aab type
+    summary: Local path of the secured secondary output file
+    title: Secured secondary output file path (universal apk)
+- APPDOME_PRIVATE_SIGN_SCRIPT_PATH: null
+  opts:
+    description: |
+      Local path of the .sh sign script file. Available when 'Signing Method' set to 'Auto-Dev-Signing'
+    summary: Local path of the .sh sign script file
+    title: .sh sign script file path
+- APPDOME_CERTIFICATE_PATH: null
+  opts:
+    summary: Local path of the Certified Secure Certificate .pdf file
+    title: Certified Secure Certificate .pdf file path
+- APPDOME_WORKFLOW_LOGS: null
+  opts:
+    summary: Local path of the Appdome workflow logs file
+    title: Appdome workflow logs file


### PR DESCRIPTION
![TagCheck](https://steplib-git-check.services.bitrise.io/tag?pr=5118)

Adds Baseline Profile and Startup Profile inputs for Android builds.
### Pull Request Checklist

- [ ] I have read the [Step Development Guideline](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step)
- [ ] I have tested the step in an actual CI/CD workflow (preferably as a workflow in the step repo's `bitrise.yml`)
- [ ] I did run `bitrise run audit-this-step` (in the step's repository - note, if you don't have this workflow in your `bitrise.yml`, [you can copy it from the step template](https://github.com/bitrise-steplib/step-template/blob/master/bitrise.yml).)
- [ ] I am aware of the [Abandoned Step policy](https://github.com/bitrise-io/bitrise-steplib#abandoned-step-policy)
- [ ] __I will not move an already shared step version's tag to another commit__

### What's next

After your PR is opened:

- Make sure you accept the Contributor terms. @CLAassistant is going to check this and tell you what to do.
- A Bitrise engineer is going to take a look at the PR. Brand new step submissions get reviewed in more detail, updates to existing steps are usually approved instantly.
- CI checks: At the moment, contributors do not have access to the CI workflow triggered by PRs. In case of a failed build, we ask for your patience.


